### PR TITLE
[SE/XLA:GPU/TF] Start cleaning up BlasLt API.

### DIFF
--- a/tensorflow/compiler/xla/service/gpu/BUILD
+++ b/tensorflow/compiler/xla/service/gpu/BUILD
@@ -1088,6 +1088,7 @@ cc_library(
         "//tensorflow/compiler/xla:shape_util",
         "//tensorflow/compiler/xla:status_macros",
         "//tensorflow/compiler/xla:statusor",
+        "//tensorflow/compiler/xla:types",
         "//tensorflow/compiler/xla:util",
         "//tensorflow/compiler/xla:xla_data_proto_cc",
         "//tensorflow/compiler/xla/service:hlo",

--- a/tensorflow/compiler/xla/service/gpu/gemm_algorithm_picker.cc
+++ b/tensorflow/compiler/xla/service/gpu/gemm_algorithm_picker.cc
@@ -23,13 +23,10 @@ limitations under the License.
 #include "tensorflow/compiler/xla/service/gpu/backend_configs.pb.h"
 #include "tensorflow/compiler/xla/service/gpu/buffer_comparator.h"
 #include "tensorflow/compiler/xla/service/gpu/gpu_asm_opts_util.h"
-#include "tensorflow/compiler/xla/service/gpu/ir_emission_utils.h"
 #include "tensorflow/compiler/xla/service/gpu/matmul_utils.h"
 #include "tensorflow/compiler/xla/service/gpu/stream_executor_util.h"
 #include "tensorflow/compiler/xla/service/hlo_computation.h"
 #include "tensorflow/compiler/xla/service/hlo_instruction.h"
-#include "tensorflow/compiler/xla/service/hlo_instructions.h"
-#include "tensorflow/compiler/xla/service/hlo_opcode.h"
 #include "tensorflow/compiler/xla/util.h"
 #include "tensorflow/core/lib/core/errors.h"
 #include "tensorflow/core/platform/logger.h"
@@ -208,78 +205,7 @@ StatusOr<std::optional<size_t>> GetBestAlgorithm(
   return {std::nullopt};
 }
 
-Status DoBlasPlansAutotune(se::Stream* stream, const HloInstruction* gemm,
-                           se::DeviceMemoryAllocator* allocator,
-                           const GemmBackendConfig& gemm_config) {
-  se::cuda::BlasLt* blas_lt = se::cuda::GetBlasLt(stream);
-  TF_RET_CHECK(blas_lt != nullptr);
-
-  TF_ASSIGN_OR_RETURN(GemmConfig config, GemmConfig::For(gemm));
-
-  const DebugOptions& debug_options =
-      gemm->GetModule()->config().debug_options();
-  AutotuneConfig autotune_config = GetConfig(debug_options);
-
-  se::RedzoneAllocator buffer_allocator =
-      CreateRedzoneAllocator(stream, allocator, debug_options, autotune_config);
-
-  int64_t rng_state = 0;
-  TF_ASSIGN_OR_RETURN(se::DeviceMemoryBase lhs_buffer,
-                      CreateBuffer(buffer_allocator, *gemm->operand(0),
-                                   autotune_config, rng_state));
-  TF_ASSIGN_OR_RETURN(se::DeviceMemoryBase rhs_buffer,
-                      CreateBuffer(buffer_allocator, *gemm->operand(1),
-                                   autotune_config, rng_state));
-  TF_ASSIGN_OR_RETURN(
-      se::DeviceMemoryBase output_buffer,
-      CreateBuffer(buffer_allocator, *gemm, autotune_config, rng_state));
-
-  TF_ASSIGN_OR_RETURN(MatmulPlanParams matmul_plan_params,
-                      GetBlasLtMatmulPlanParams(config));
-
-  BlasPlansAutotuneCache& cache = GetBlasPlansAutotuneCache();
-  if (cache.Find(matmul_plan_params.params)) {
-    return OkStatus();
-  }
-
-  se::cuda::BlasLt::MatmulPlan matmul_plan;
-  TF_RETURN_IF_ERROR(matmul_plan.init(matmul_plan_params.params));
-
-  if (matmul_plan_params.must_swap_operands) {
-    std::swap(lhs_buffer, rhs_buffer);
-  }
-
-  constexpr int kMaxAlgorithmCount = 100;
-  TF_ASSIGN_OR_RETURN(
-      std::vector<se::cuda::BlasLt::MatmulAlgorithm> algorithms,
-      blas_lt->GetMatmulAlgorithms(matmul_plan, kBlasLtMaxWorkspaceSize,
-                                   kMaxAlgorithmCount));
-
-  TF_ASSIGN_OR_RETURN(
-      std::optional<size_t> best_algorithm_idx,
-      GetBestAlgorithm<se::cuda::BlasLt::MatmulAlgorithm>(
-          stream, buffer_allocator, *gemm, autotune_config, lhs_buffer,
-          rhs_buffer, output_buffer, algorithms,
-          [&](const se::cuda::BlasLt::MatmulAlgorithm& algorithm)
-              -> StatusOr<se::blas::ProfileResult> {
-            se::OwningScratchAllocator<> scratch_allocator(
-                stream->parent()->device_ordinal(), allocator);
-            se::blas::ProfileResult profile_result;
-            TF_RETURN_IF_ERROR(RunBlasLtMatmul(
-                matmul_plan, config.alpha, lhs_buffer, rhs_buffer, config.beta,
-                output_buffer, stream, scratch_allocator, &algorithm,
-                &profile_result));
-            return std::move(profile_result);
-          }));
-
-  if (best_algorithm_idx) {
-    cache.Insert(std::move(matmul_plan_params.params),
-                 se::blas::AlgorithmConfig(*best_algorithm_idx));
-  }
-  return OkStatus();
-}
-
-static StatusOr<std::optional<se::blas::AlgorithmType>> DoGemmAutotune(
+StatusOr<std::optional<se::blas::AlgorithmType>> DoGemmAutotune(
     const HloInstruction* gemm, const GemmBackendConfig& gemm_config,
     se::DeviceMemoryAllocator* allocator, se::Stream* stream) {
   VLOG(3) << "Starting autotune of GemmThunk " << gemm->ToString();
@@ -289,12 +215,6 @@ static StatusOr<std::optional<se::blas::AlgorithmType>> DoGemmAutotune(
   TF_ASSIGN_OR_RETURN(GemmConfig config, GemmConfig::For(gemm));
   // Don't run autotuning concurrently on the same GPU.
   absl::MutexLock gpu_lock(&GetGpuMutex(stream->parent()));
-
-  if (config.use_cublaslt) {
-    TF_RETURN_IF_ERROR(
-        DoBlasPlansAutotune(stream, gemm, allocator, gemm_config));
-    return {se::blas::kNoAlgorithm};
-  }
 
   auto key = std::make_tuple(stream->parent(), lhs->shape(), rhs->shape(),
                              gemm->shape(), gemm_config.SerializeAsString());
@@ -324,9 +244,6 @@ static StatusOr<std::optional<se::blas::AlgorithmType>> DoGemmAutotune(
   cache_misses++;
   VLOG(4) << "Autotuning cache miss";
 
-  std::vector<se::blas::AlgorithmType> algorithms;
-  CHECK(stream->parent()->GetBlasGemmAlgorithms(stream, &algorithms));
-
   const DebugOptions& debug_options =
       gemm->GetModule()->config().debug_options();
   AutotuneConfig autotune_config = GetConfig(debug_options);
@@ -345,27 +262,57 @@ static StatusOr<std::optional<se::blas::AlgorithmType>> DoGemmAutotune(
       se::DeviceMemoryBase output_buffer,
       CreateBuffer(buffer_allocator, *gemm, autotune_config, rng_state));
 
-  TF_ASSIGN_OR_RETURN(
-      std::optional<size_t> best_algorithm_idx,
-      GetBestAlgorithm<se::blas::AlgorithmType>(
-          stream, buffer_allocator, *gemm, autotune_config, lhs_buffer,
-          rhs_buffer, output_buffer, algorithms,
-          [&](const se::blas::AlgorithmType& algorithm)
-              -> StatusOr<se::blas::ProfileResult> {
-            se::blas::ProfileResult profile_result;
-            // We expect GemmWithAlgorithm to fail sometimes -- in fact, it will
-            // fail for all algorithms if we're targeting < sm_50.  But because
-            // we pass a non-null ProfileResult, DoGemmWithAlgorithm should
-            // always return true, and the actual success-ness is returned in
-            // ProfileResult::is_valid.
-            TF_RETURN_IF_ERROR(RunGemm(config, lhs_buffer, rhs_buffer,
-                                       output_buffer, stream, algorithm,
-                                       &profile_result));
-            return std::move(profile_result);
-          }));
-
   std::optional<se::blas::AlgorithmType> best_algorithm;
-  if (best_algorithm_idx) best_algorithm = algorithms[*best_algorithm_idx];
+  if (config.use_cublaslt) {
+    TF_ASSIGN_OR_RETURN(auto plan, cublas_lt::MatmulPlan::From(config));
+    TF_ASSIGN_OR_RETURN(
+        std::vector<se::cuda::BlasLt::MatmulAlgorithm> algorithms,
+        plan.GetAlgorithms(stream));
+
+    TF_ASSIGN_OR_RETURN(
+        std::optional<size_t> best_algorithm_idx,
+        GetBestAlgorithm<se::cuda::BlasLt::MatmulAlgorithm>(
+            stream, buffer_allocator, *gemm, autotune_config, lhs_buffer,
+            rhs_buffer, output_buffer, algorithms,
+            [&](const se::cuda::BlasLt::MatmulAlgorithm& algorithm)
+                -> StatusOr<se::blas::ProfileResult> {
+              se::OwningScratchAllocator<> scratch_allocator(
+                  stream->parent()->device_ordinal(), allocator);
+              se::blas::ProfileResult profile_result;
+              TF_RETURN_IF_ERROR(plan.ExecuteOnStream(
+                  stream, lhs_buffer, rhs_buffer, output_buffer, algorithm,
+                  scratch_allocator, &profile_result));
+              return std::move(profile_result);
+            }));
+
+    TF_RET_CHECK(best_algorithm_idx) << "failed to auto-tune cublas_lt matmul";
+    best_algorithm = *best_algorithm_idx;
+  } else {
+    std::vector<se::blas::AlgorithmType> algorithms;
+    TF_RET_CHECK(stream->parent()->GetBlasGemmAlgorithms(stream, &algorithms));
+
+    TF_ASSIGN_OR_RETURN(std::optional<size_t> best_algorithm_idx,
+                        GetBestAlgorithm<se::blas::AlgorithmType>(
+                            stream, buffer_allocator, *gemm, autotune_config,
+                            lhs_buffer, rhs_buffer, output_buffer, algorithms,
+                            [&](const se::blas::AlgorithmType& algorithm)
+                                -> StatusOr<se::blas::ProfileResult> {
+                              se::blas::ProfileResult profile_result;
+                              // We expect GemmWithAlgorithm to fail sometimes
+                              // -- in fact, it will fail for all algorithms if
+                              // we're targeting < sm_50.  But because we pass a
+                              // non-null ProfileResult, DoGemmWithAlgorithm
+                              // should always return true, and the actual
+                              // success-ness is returned in
+                              // ProfileResult::is_valid.
+                              TF_RETURN_IF_ERROR(RunGemm(
+                                  config, lhs_buffer, rhs_buffer, output_buffer,
+                                  stream, algorithm, &profile_result));
+                              return std::move(profile_result);
+                            }));
+
+    if (best_algorithm_idx) best_algorithm = algorithms[*best_algorithm_idx];
+  }
 
   CHECK(cache.emplace(key, best_algorithm).second);
   return best_algorithm;

--- a/tensorflow/compiler/xla/service/gpu/gemm_thunk.cc
+++ b/tensorflow/compiler/xla/service/gpu/gemm_thunk.cc
@@ -52,26 +52,24 @@ Status GemmThunk::ExecuteOnStream(const ExecuteParams& params) {
   VLOG(3) << "Running GEMM thunk";
 #if GOOGLE_CUDA
   if (config_.use_cublaslt) {
-    auto &buffer_allocations = *params.buffer_allocations;
+    if (!matmul_plan_and_algorithm_) {
+      TF_ASSIGN_OR_RETURN(auto plan, cublas_lt::MatmulPlan::From(config_));
+      TF_RET_CHECK(config_.algorithm);
+      TF_ASSIGN_OR_RETURN(
+          std::vector<se::cuda::BlasLt::MatmulAlgorithm> algorithms,
+          plan.GetAlgorithms(params.stream));
+      matmul_plan_and_algorithm_ = {std::move(plan),
+                                    std::move(algorithms[*config_.algorithm])};
+    }
+
+    auto& [plan, algorithm] = *matmul_plan_and_algorithm_;
+
     se::OwningScratchAllocator<> scratch_allocator(
-        buffer_allocations.device_ordinal(),
-        buffer_allocations.memory_allocator());
+        params.buffer_allocations->device_ordinal(),
+        params.buffer_allocations->memory_allocator());
 
-    TF_ASSIGN_OR_RETURN(MatmulPlanParams matmul_plan_params,
-                        GetBlasLtMatmulPlanParams(config_));
-
-    if (!matmul_plan_) {
-      matmul_plan_ = se::cuda::BlasLt::MatmulPlan();
-      TF_RETURN_IF_ERROR(matmul_plan_->init(matmul_plan_params.params));
-    }
-
-    if (matmul_plan_params.must_swap_operands) {
-      std::swap(lhs_data, rhs_data);
-    }
-
-    return RunBlasLtMatmul(*matmul_plan_, config_.alpha, lhs_data, rhs_data,
-                           config_.beta, output_data, params.stream,
-                           scratch_allocator);
+    return plan.ExecuteOnStream(params.stream, lhs_data, rhs_data, output_data,
+                                algorithm, scratch_allocator);
   }
 #endif  // GOOGLE_CUDA
 

--- a/tensorflow/compiler/xla/service/gpu/gemm_thunk.h
+++ b/tensorflow/compiler/xla/service/gpu/gemm_thunk.h
@@ -51,7 +51,9 @@ class GemmThunk : public Thunk {
   const BufferAllocation::Slice rhs_buffer_;
   const BufferAllocation::Slice output_buffer_;
 #if GOOGLE_CUDA
-  std::optional<se::cuda::BlasLt::MatmulPlan> matmul_plan_;
+  std::optional<
+      std::pair<cublas_lt::MatmulPlan, se::cuda::BlasLt::MatmulAlgorithm>>
+      matmul_plan_and_algorithm_;
 #endif  // GOOGLE_CUDA
 };
 

--- a/tensorflow/compiler/xla/service/gpu/matmul_utils.cc
+++ b/tensorflow/compiler/xla/service/gpu/matmul_utils.cc
@@ -33,6 +33,7 @@ limitations under the License.
 #include "tensorflow/compiler/xla/shape_util.h"
 #include "tensorflow/compiler/xla/status_macros.h"
 #include "tensorflow/compiler/xla/statusor.h"
+#include "tensorflow/compiler/xla/types.h"
 #include "tensorflow/compiler/xla/util.h"
 #include "tensorflow/compiler/xla/xla_data.pb.h"
 #include "tensorflow/core/platform/statusor.h"
@@ -231,7 +232,7 @@ StatusOr<bool> CanFoldTransposeOperandIntoDot(const HloInstruction& dot,
 
 namespace {
 
-bool IsBlasPlansCompatibleType(PrimitiveType type) {
+bool IsBlasLtCompatible(PrimitiveType type) {
   switch (type) {
     case F16:
     case F32:
@@ -302,7 +303,7 @@ bool IsBlasPlansCompatibleType(PrimitiveType type) {
   TF_RET_CHECK((rhs_layout.batch_size == output_layout.batch_size) ||
                (rhs_layout.batch_size == 1));
 
-  use_cublaslt &= IsBlasPlansCompatibleType(output_shape.element_type());
+  use_cublaslt &= IsBlasLtCompatible(output_shape.element_type());
 
   switch (output_shape.element_type()) {
     case F16:
@@ -603,144 +604,134 @@ StatusOr<se::blas::DataType> AsBlasDataType(PrimitiveType dtype) {
   }
 }
 
-template <typename Input>
-Status DoGemmLt(const se::cuda::BlasLt::MatmulPlan& plan, Input alpha,
-                se::DeviceMemoryBase lhs_buffer,
-                se::DeviceMemoryBase rhs_buffer, Input beta,
-                se::DeviceMemoryBase output_buffer, se::Stream* stream,
-                se::ScratchAllocator& scratch_allocator,
-                const se::cuda::BlasLt::MatmulAlgorithm* algorithm,
-                se::blas::ProfileResult* profile_result) {
-  se::cuda::BlasLt* blas_lt = se::cuda::GetBlasLt(stream);
-  TF_RET_CHECK(blas_lt != nullptr);
+StatusOr<se::cuda::BlasLt::MatrixLayout> AsBlasLtMatrixLayout(
+    const MatrixLayout& layout) {
+  TF_ASSIGN_OR_RETURN(se::blas::DataType dtype, AsBlasDataType(layout.dtype));
 
-  TF_ASSIGN_OR_RETURN(
-      se::cuda::BlasLt::MatmulAlgorithm algo,
-      [&]() -> StatusOr<se::cuda::BlasLt::MatmulAlgorithm> {
-        if (algorithm != nullptr) {
-          return *algorithm;
-        } else {
-          BlasPlansAutotuneCache& cache = GetBlasPlansAutotuneCache();
-          std::optional<se::blas::AlgorithmConfig> algorithm_config =
-              cache.Find(plan.params());
+  auto order = (layout.order == MatrixLayout::Order::kColumnMajor)
+                   ? se::cuda::BlasLt::MatrixLayout::Order::kColumnMajor
+                   : se::cuda::BlasLt::MatrixLayout::Order::kRowMajor;
 
-          if (!algorithm_config) {
-            VLOG(4) << "Autotuner disabled: Using algorithm 0";
-            cache.Insert(plan.params(), se::blas::AlgorithmConfig(0));
-            algorithm_config = se::blas::AlgorithmConfig(0);
-          }
-
-          int max_algorithm_count = algorithm_config->algorithm() + 1;
-          TF_ASSIGN_OR_RETURN(
-              std::vector<se::cuda::BlasLt::MatmulAlgorithm> algorithms,
-              blas_lt->GetMatmulAlgorithms(plan, kBlasLtMaxWorkspaceSize,
-                                           max_algorithm_count));
-
-          return algorithms[algorithm_config->algorithm()];
-        }
-      }());
-
-  se::DeviceMemory<Input> output_data(output_buffer);
-  if (blas_lt->DoMatmul(stream, plan, se::HostOrDeviceScalar<Input>(alpha),
-                        se::DeviceMemory<Input>(lhs_buffer),
-                        se::DeviceMemory<Input>(rhs_buffer),
-                        se::HostOrDeviceScalar<Input>(beta), &output_data,
-                        &scratch_allocator, algo, /*bias=*/{},
-                        profile_result)) {
-    return OkStatus();
-  }
-  return InternalError("BlasLtMatmul failed.");
+  return se::cuda::BlasLt::MatrixLayout::Create(
+      dtype, layout.num_rows, layout.num_cols, order, layout.batch_size,
+      layout.leading_dim_stride, layout.batch_stride);
 }
 
 }  // namespace
 
-StatusOr<MatmulPlanParams> GetBlasLtMatmulPlanParams(const GemmConfig& config) {
+namespace cublas_lt {
+
+/*static*/ StatusOr<MatmulPlan> MatmulPlan::From(const GemmConfig& config) {
   MatrixLayout lhs_layout = config.lhs_layout;
   MatrixLayout rhs_layout = config.rhs_layout;
   MatrixLayout output_layout = config.output_layout;
   bool must_swap_operands =
       MakeOutputColumnMajor(lhs_layout, rhs_layout, output_layout);
 
-  TF_ASSIGN_OR_RETURN(se::blas::DataType dtype,
+  TF_ASSIGN_OR_RETURN(se::blas::DataType output_dtype,
                       AsBlasDataType(output_layout.dtype));
   TF_ASSIGN_OR_RETURN(se::blas::ComputationType computation_type,
                       GetBlasComputationType(output_layout.dtype));
 
-  se::cuda::BlasLt::MatmulPlanParams params{
-      /*ab_type=*/dtype,
-      /*c_type=*/dtype,
-      computation_type,
-      se::cuda::BlasLt::PointerMode::kHost,
-      se::cuda::BlasLt::Epilogue::kDefault,
-      AsBlasTranspose(lhs_layout.order),
-      AsBlasTranspose(rhs_layout.order),
-      static_cast<uint64_t>(output_layout.num_rows),
-      static_cast<uint64_t>(output_layout.num_cols),
-      static_cast<uint64_t>(lhs_layout.num_cols),
-      lhs_layout.leading_dim_stride,
-      rhs_layout.leading_dim_stride,
-      output_layout.leading_dim_stride,
-      static_cast<int>(output_layout.batch_size),
-      lhs_layout.batch_stride,
-      rhs_layout.batch_stride,
-      output_layout.batch_stride};
+  se::blas::DataType scale_type =
+      ((output_layout.dtype == F16) || (output_layout.dtype == BF16))
+          ? se::blas::DataType::kFloat
+          : output_dtype;
 
-  return MatmulPlanParams{params, must_swap_operands};
+  TF_ASSIGN_OR_RETURN(
+      se::cuda::BlasLt::MatmulDesc op_desc,
+      se::cuda::BlasLt::MatmulDesc::Create(computation_type, scale_type));
+  TF_ASSIGN_OR_RETURN(se::cuda::BlasLt::MatrixLayout a_desc,
+                      AsBlasLtMatrixLayout(lhs_layout));
+  TF_ASSIGN_OR_RETURN(se::cuda::BlasLt::MatrixLayout b_desc,
+                      AsBlasLtMatrixLayout(rhs_layout));
+  TF_ASSIGN_OR_RETURN(se::cuda::BlasLt::MatrixLayout c_desc,
+                      AsBlasLtMatrixLayout(output_layout));
+  TF_ASSIGN_OR_RETURN(se::cuda::BlasLt::MatrixLayout d_desc,
+                      AsBlasLtMatrixLayout(output_layout));
+
+  return MatmulPlan{
+      se::cuda::BlasLt::MatmulPlan{std::move(op_desc), std::move(a_desc),
+                                   std::move(b_desc), std::move(c_desc),
+                                   std::move(d_desc)},
+      config.alpha, config.beta, must_swap_operands};
 }
 
-Status RunBlasLtMatmul(const se::cuda::BlasLt::MatmulPlan& plan,
-                       complex128 alpha, se::DeviceMemoryBase lhs_buffer,
-                       se::DeviceMemoryBase rhs_buffer, double beta,
-                       se::DeviceMemoryBase output_buffer, se::Stream* stream,
-                       se::ScratchAllocator& scratch_allocator,
-                       const se::cuda::BlasLt::MatmulAlgorithm* algorithm,
-                       se::blas::ProfileResult* profile_result) {
-  switch (plan.c_type()) {
-    case se::blas::DataType::kHalf:
-      return DoGemmLt(plan, static_cast<Eigen::half>(alpha.real()), lhs_buffer,
-                      rhs_buffer, static_cast<Eigen::half>(beta), output_buffer,
-                      stream, scratch_allocator, algorithm, profile_result);
-    case se::blas::DataType::kFloat:
-      return DoGemmLt(plan, static_cast<float>(alpha.real()), lhs_buffer,
-                      rhs_buffer, static_cast<float>(beta), output_buffer,
-                      stream, scratch_allocator, algorithm, profile_result);
-    case se::blas::DataType::kDouble:
-      return DoGemmLt(plan, alpha.real(), lhs_buffer, rhs_buffer, beta,
-                      output_buffer, stream, scratch_allocator, algorithm,
-                      profile_result);
-    case se::blas::DataType::kComplexFloat:
-      return DoGemmLt(plan, static_cast<complex64>(alpha), lhs_buffer,
-                      rhs_buffer, static_cast<complex64>(beta), output_buffer,
-                      stream, scratch_allocator, algorithm, profile_result);
-    case se::blas::DataType::kComplexDouble:
-      return DoGemmLt(plan, alpha, lhs_buffer, rhs_buffer,
-                      static_cast<complex128>(beta), output_buffer, stream,
-                      scratch_allocator, algorithm, profile_result);
+template <typename Input, typename Scale>
+Status MatmulPlan::DoMatmul(se::Stream* stream, se::DeviceMemoryBase lhs_buffer,
+                            se::DeviceMemoryBase rhs_buffer,
+                            se::DeviceMemoryBase output_buffer,
+                            const se::cuda::BlasLt::MatmulAlgorithm& algorithm,
+                            se::ScratchAllocator& scratch_allocator,
+                            se::blas::ProfileResult* profile_result) {
+  se::cuda::BlasLt* blas_lt = se::cuda::GetBlasLt(stream);
+  TF_RET_CHECK(blas_lt != nullptr);
+
+  Scale alpha;
+  if constexpr (std::is_same_v<Scale, complex64> ||
+                std::is_same_v<Scale, complex128>) {
+    alpha = static_cast<Scale>(alpha_);
+  } else {
+    alpha = static_cast<Scale>(alpha_.real());
+  }
+
+  Scale beta = static_cast<Scale>(beta_);
+
+  se::DeviceMemory<Input> output(output_buffer);
+  return blas_lt->DoMatmul(
+      stream, plan_, se::HostOrDeviceScalar<Scale>(alpha),
+      se::DeviceMemory<Input>(lhs_buffer), se::DeviceMemory<Input>(rhs_buffer),
+      se::HostOrDeviceScalar<Scale>(beta), /*c=*/output, /*d=*/output,
+      algorithm, scratch_allocator, /*bias=*/{}, profile_result);
+}
+
+Status MatmulPlan::ExecuteOnStream(
+    se::Stream* stream, se::DeviceMemoryBase lhs_buffer,
+    se::DeviceMemoryBase rhs_buffer, se::DeviceMemoryBase output_buffer,
+    const se::cuda::BlasLt::MatmulAlgorithm& algorithm,
+    se::ScratchAllocator& scratch_allocator,
+    se::blas::ProfileResult* profile_result) {
+  if (must_swap_operands_) {
+    std::swap(lhs_buffer, rhs_buffer);
+  }
+
+  switch (plan_.d_desc.type()) {
+    case CUDA_R_16F:
+      return DoMatmul<Eigen::half, float>(stream, lhs_buffer, rhs_buffer,
+                                          output_buffer, algorithm,
+                                          scratch_allocator, profile_result);
+    case CUDA_R_16BF:
+      return DoMatmul<Eigen::bfloat16, float>(
+          stream, lhs_buffer, rhs_buffer, output_buffer, algorithm,
+          scratch_allocator, profile_result);
+    case CUDA_R_32F:
+      return DoMatmul<float>(stream, lhs_buffer, rhs_buffer, output_buffer,
+                             algorithm, scratch_allocator, profile_result);
+    case CUDA_R_64F:
+      return DoMatmul<double>(stream, lhs_buffer, rhs_buffer, output_buffer,
+                              algorithm, scratch_allocator, profile_result);
+    case CUDA_C_32F:
+      return DoMatmul<complex64>(stream, lhs_buffer, rhs_buffer, output_buffer,
+                                 algorithm, scratch_allocator, profile_result);
+    case CUDA_C_64F:
+      return DoMatmul<complex128>(stream, lhs_buffer, rhs_buffer, output_buffer,
+                                  algorithm, scratch_allocator, profile_result);
     default:
       return InternalError("Unexpected dtype");
   }
 }
 
-std::optional<se::blas::AlgorithmConfig> BlasPlansAutotuneCache::Find(
-    const se::cuda::BlasLt::MatmulPlanParams& params) const {
-  absl::MutexLock lock(&mu_);
-  auto it = blas_plans_algorithms_map_.find(params);
-  if (it == blas_plans_algorithms_map_.end()) {
-    return std::nullopt;
-  }
-  return it->second;
+StatusOr<std::vector<se::cuda::BlasLt::MatmulAlgorithm>>
+MatmulPlan::GetAlgorithms(se::Stream* stream) const {
+  se::cuda::BlasLt* blas_lt = se::cuda::GetBlasLt(stream);
+  TF_RET_CHECK(blas_lt != nullptr);
+  TF_ASSIGN_OR_RETURN(auto preference,
+                      se::cuda::BlasLt::MatmulPreference::Create(
+                          /*max_workspace_size=*/1ll << 32));  // 4GB
+  return blas_lt->GetMatmulAlgorithms(plan_, preference);
 }
 
-void BlasPlansAutotuneCache::Insert(se::cuda::BlasLt::MatmulPlanParams params,
-                                    se::blas::AlgorithmConfig config) {
-  absl::MutexLock lock(&mu_);
-  blas_plans_algorithms_map_.insert({std::move(params), std::move(config)});
-}
-
-BlasPlansAutotuneCache& GetBlasPlansAutotuneCache() {
-  static auto& instance = *new BlasPlansAutotuneCache();
-  return instance;
-}
+}  // namespace cublas_lt
 
 #endif  // GOOGLE_CUDA
 

--- a/tensorflow/core/kernels/matmul_op_fused.cc
+++ b/tensorflow/core/kernels/matmul_op_fused.cc
@@ -181,8 +181,8 @@ StatusOr<se::cuda::BlasLt::Epilogue> GetBlasLtEpilogOp(
 template <typename LaunchFunc>
 se::blas::AlgorithmConfig AutotuneMatmul(
     const std::vector<se::cuda::BlasLt::MatmulAlgorithm>& algorithms,
-    const se::cuda::BlasLt::MatmulPlanParams& matmul_params,
-    OpKernelContext* context, const LaunchFunc& launch_func) {
+    BlasLtMatmulPlanParams& matmul_params, OpKernelContext* context,
+    const LaunchFunc& launch_func) {
   // Note that algorithm_config.algorithm() here is used to refer
   // to the index within the algorithms vector, not the algorithm
   // itself.
@@ -201,18 +201,20 @@ se::blas::AlgorithmConfig AutotuneMatmul(
       // scratch space is deallocated between runs.
       BlasScratchAllocator scratch_allocator(context);
 
-      bool cublaslt_launch_ok =
-          launch_func(&scratch_allocator, profile_algorithm, &profile_result);
+      Status cublaslt_launch =
+          launch_func(scratch_allocator, profile_algorithm, &profile_result);
 
       VLOG(4) << "  Autotune algorithm " << i
               << " result: " << profile_result.elapsed_time_in_ms()
               << " ms, valid=" << profile_result.is_valid()
-              << ", workspace_size=" << profile_algorithm.workspace_size();
+              << ", workspace_size=" << profile_algorithm.workspace_size;
 
-      if (cublaslt_launch_ok && profile_result.is_valid() &&
+      if (cublaslt_launch.ok() && profile_result.is_valid() &&
           profile_result.elapsed_time_in_ms() <
               best_result.elapsed_time_in_ms()) {
         best_result = profile_result;
+        // Use index into algorithms array, instead of cublas internal ID.
+        best_result.set_algorithm(i);
       }
     }
 
@@ -273,36 +275,16 @@ struct LaunchFusedMatMulOp<GPUDevice, T> {
     const int64_t k = a.dim_size(trans_a ? 0 : 1);
     const int64_t n = b.dim_size(trans_b ? 0 : 1);
 
-    se::blas::DataType blas_dtype = se::blas::ToDataType<T>::value;
-
-    DataType dtype = DataTypeToEnum<T>::value;
-    auto status_or_computation_type = GetBlasComputationType(dtype);
-    OP_REQUIRES(context, status_or_computation_type.ok(),
-                errors::Internal("Unsupported dtype for batched matmul."));
-    se::blas::ComputationType computation_type =
-        std::move(status_or_computation_type).value();
-
     se::blas::Transpose trans[] = {se::blas::Transpose::kNoTranspose,
                                    se::blas::Transpose::kTranspose};
 
-    se::cuda::BlasLt::MatmulPlanParams matmul_params{
-        /*ab_type=*/blas_dtype,
-        /*c_type=*/blas_dtype,
-        computation_type,
-        se::cuda::BlasLt::PointerMode::kHost,
-        epilog_op,
-        trans[trans_b ? 1 : 0],
+    BlasLtMatmulPlanParams matmul_params{
+        se::blas::ToDataType<T>::value, static_cast<size_t>(m),
+        static_cast<size_t>(n),         static_cast<size_t>(k),
+        trans[trans_a ? 1 : 0],         trans[trans_b ? 1 : 0],
         trans[trans_a ? 1 : 0],
-        static_cast<uint64_t>(n),
-        static_cast<uint64_t>(m),
-        static_cast<uint64_t>(k),
-        trans_b ? k : n,
-        trans_a ? m : k,
-        static_cast<int64_t>(n),
-        /*batch_size=*/1,
-        static_cast<int64_t>(k * n),
-        static_cast<int64_t>(m * k),
-        static_cast<int64_t>(m * n)};
+        /*broadcast_a=*/false,
+        /*broadcast_b=*/false,          epilog_op};
 
     auto plan_and_algorithms_or = GetPlanAndAlgorithms(stream, matmul_params);
     OP_REQUIRES_OK(context, plan_and_algorithms_or.status());
@@ -320,12 +302,13 @@ struct LaunchFusedMatMulOp<GPUDevice, T> {
     OP_REQUIRES(context, blas_lt != nullptr,
                 errors::Internal("blaslt not supported"));
 
-    auto launch_func = [&](BlasScratchAllocator* scratch_allocator,
+    auto launch_func = [&](BlasScratchAllocator& scratch_allocator,
                            const se::cuda::BlasLt::MatmulAlgorithm& algorithm,
-                           se::blas::ProfileResult* profile_result) -> bool {
-      return blas_lt->DoMatmul(stream, plan, alpha, b_ptr, a_ptr, beta, c_ptr,
-                               scratch_allocator, algorithm, bias_ptr,
-                               profile_result);
+                           se::blas::ProfileResult* profile_result) {
+      return blas_lt->DoMatmul(stream, plan, se::HostOrDeviceScalar<T>(alpha),
+                               b_ptr, a_ptr, se::HostOrDeviceScalar<T>(beta),
+                               c_ptr, c_ptr, algorithm, scratch_allocator,
+                               bias_ptr, profile_result);
     };
 
     se::cuda::BlasLt::MatmulAlgorithm algorithm = algorithms[0];
@@ -338,16 +321,7 @@ struct LaunchFusedMatMulOp<GPUDevice, T> {
     }
 
     BlasScratchAllocator scratch_allocator(context);
-
-    bool cublaslt_launch_ok =
-        launch_func(&scratch_allocator, algorithm, nullptr);
-    if (!cublaslt_launch_ok) {
-      OP_REQUIRES_OK(context,
-                     errors::Internal("BlasLt Matmul launch failed : a.shape=",
-                                      a.shape().DebugString(),
-                                      ", b.shape=", b.shape().DebugString(),
-                                      ", m=", m, ", n=", n, ", k=", k));
-    }
+    OP_REQUIRES_OK(context, launch_func(scratch_allocator, algorithm, nullptr));
   }
 };
 

--- a/tensorflow/core/kernels/matmul_op_impl.h
+++ b/tensorflow/core/kernels/matmul_op_impl.h
@@ -291,9 +291,9 @@ struct BlasLtMatmulAutoTuneGroup {
   static string name() { return "MatmulLt"; }
 };
 
-typedef AutotuneSingleton<
-    BlasLtMatmulAutoTuneGroup, se::cuda::BlasLt::MatmulPlanParams,
-    se::blas::AlgorithmConfig, absl::Hash<se::cuda::BlasLt::MatmulPlanParams>>
+typedef AutotuneSingleton<BlasLtMatmulAutoTuneGroup, BlasLtMatmulPlanParams,
+                          se::blas::AlgorithmConfig,
+                          absl::Hash<BlasLtMatmulPlanParams>>
     AutoTuneBatchMatmul;
 
 }  // namespace
@@ -407,11 +407,6 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
           bcast.IsBroadcastingRequired() && !is_full_broadcast;
 
       if (!requires_mixed_broadcasting) {
-        bool broadcast_a = bcast.x_batch_size() == 1;
-        bool broadcast_b = bcast.y_batch_size() == 1;
-        a_stride = broadcast_a ? 0 : m * k;
-        b_stride = broadcast_b ? 0 : k * n;
-        c_stride = m * n;
         a_device_memory.push_back(AsDeviceMemory(a_base_ptr));
         b_device_memory.push_back(AsDeviceMemory(b_base_ptr));
         c_device_memory.push_back(AsDeviceMemory(c_base_ptr));
@@ -419,33 +414,16 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
         b_ptrs.push_back(&b_device_memory.back());
         c_ptrs.push_back(&c_device_memory.back());
 
-        se::blas::DataType blas_dtype = se::blas::ToDataType<Scalar>::value;
-
-        DataType dtype = DataTypeToEnum<Scalar>::value;
-        auto status_or_computation_type = GetBlasComputationType(dtype);
-        OP_REQUIRES(context, status_or_computation_type.ok(),
-                    errors::Internal("Unsupported dtype for batched matmul."));
-        se::blas::ComputationType computation_type =
-            std::move(status_or_computation_type).value();
-
-        se::cuda::BlasLt::MatmulPlanParams matmul_params{
-            /*ab_type=*/blas_dtype,
-            /*c_type=*/blas_dtype,
-            computation_type,
-            se::cuda::BlasLt::PointerMode::kHost,
-            se::cuda::BlasLt::Epilogue::kDefault,
-            blas_transpose_b,
+        BlasLtMatmulPlanParams matmul_params{
+            se::blas::ToDataType<Scalar>::value,
+            static_cast<size_t>(m),
+            static_cast<size_t>(n),
+            static_cast<size_t>(k),
             blas_transpose_a,
-            static_cast<uint64_t>(n),
-            static_cast<uint64_t>(m),
-            static_cast<uint64_t>(k),
-            in_y.dim_size(2),
-            in_x.dim_size(2),
-            static_cast<int64_t>(n),
-            static_cast<int>(batch_size),
-            static_cast<int64_t>(b_stride),
-            static_cast<int64_t>(a_stride),
-            static_cast<int64_t>(c_stride)};
+            blas_transpose_b,
+            static_cast<size_t>(batch_size),
+            /*broadcast_a=*/bcast.x_batch_size() == 1,
+            /*broadcast_b=*/bcast.y_batch_size() == 1};
 
         std::optional<int> max_algorithm_count;
         if (!use_autotune) max_algorithm_count = 1;
@@ -482,21 +460,22 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
             // Create a new scratch allocator with every autotuning run so that
             // scratch space is deallocated between runs.
             BlasScratchAllocator scratch_allocator(context, max_scratch_size);
-            bool cublas_launch_status = blas_lt->DoMatmul(
-                stream, plan, alpha, *b_ptrs[0], *a_ptrs[0], beta, c_ptrs[0],
-                &scratch_allocator, profile_algorithm,
+            Status cublas_launch_status = blas_lt->DoMatmul(
+                stream, plan, alpha, *b_ptrs[0], *a_ptrs[0], beta, *c_ptrs[0],
+                *c_ptrs[0], profile_algorithm, scratch_allocator,
                 /*bias = */ {}, &profile_result);
 
             VLOG(4) << "  Autotune algorithm " << i
                     << " result: " << profile_result.elapsed_time_in_ms()
                     << " ms, valid=" << profile_result.is_valid()
-                    << ", workspace_size="
-                    << profile_algorithm.workspace_size();
+                    << ", workspace_size=" << profile_algorithm.workspace_size;
 
-            if (cublas_launch_status && profile_result.is_valid() &&
+            if (cublas_launch_status.ok() && profile_result.is_valid() &&
                 profile_result.elapsed_time_in_ms() <
                     best_result.elapsed_time_in_ms()) {
               best_result = profile_result;
+              // Use index into algorithms array, instead of cublas internal ID.
+              best_result.set_algorithm(i);
             }
           }
 
@@ -523,17 +502,10 @@ struct LaunchBatchMatMul<GPUDevice, Scalar> {
                 << "trans_x = " << trans_x << "trans_y = " << trans_y
                 << "adj_x = " << adj_x << "adj_y = " << adj_y;
 
-        bool cublas_launch_status =
-            blas_lt->DoMatmul(stream, plan, alpha, *b_ptrs[0], *a_ptrs[0], beta,
-                              c_ptrs[0], &scratch_allocator, algorithm);
-        if (!cublas_launch_status) {
-          context->SetStatus(errors::Internal(
-              "Blas batched matmul launch failed: a.shape=(",
-              bcast.x_batch_size(), ", ", in_x.dim_size(0), ", ",
-              in_x.dim_size(1), "), b.shape=(", bcast.y_batch_size(), ", ",
-              in_y.dim_size(0), ", ", in_y.dim_size(1), "), m=", m, ", n=", n,
-              ", k=", k, ", batch_size=", batch_size));
-        }
+        OP_REQUIRES_OK(
+            context, blas_lt->DoMatmul(stream, plan, alpha, *b_ptrs[0],
+                                       *a_ptrs[0], beta, *c_ptrs[0], *c_ptrs[0],
+                                       algorithm, scratch_allocator));
       } else {  // requires mixed broadcasting
         const std::vector<int64_t>& a_batch_indices = bcast.x_batch_indices();
         const std::vector<int64_t>& b_batch_indices = bcast.y_batch_indices();

--- a/tensorflow/core/kernels/matmul_util.cc
+++ b/tensorflow/core/kernels/matmul_util.cc
@@ -12,6 +12,7 @@ limitations under the License.
 
 #include "tensorflow/core/kernels/matmul_util.h"
 
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -41,6 +42,30 @@ int64_t GetWorkspaceLimit(int64_t default_value_in_bytes) {
   return default_value_in_bytes;
 }
 
+std::string BlasLtMatmulPlanParams::ToString() const {
+  return "";  // TODO
+}
+
+bool BlasLtMatmulPlanParams::operator==(
+    const BlasLtMatmulPlanParams& other) const {
+  return internal::AsTuple(*this) == internal::AsTuple(other);
+}
+
+const PlanAndAlgorithms* BlasLtMatmulPlanMap::Find(
+    const BlasLtMatmulPlanParams& params) const {
+  absl::MutexLock lock(&mu_);
+  auto it = params_plan_map_.find(params);
+  return (it != params_plan_map_.end()) ? &it->second : nullptr;
+}
+
+const PlanAndAlgorithms* BlasLtMatmulPlanMap::Insert(
+    const BlasLtMatmulPlanParams& params, PlanAndAlgorithms value) {
+  absl::MutexLock lock(&mu_);
+  return &params_plan_map_.emplace(params, std::move(value)).first->second;
+}
+
+namespace {
+
 int MatmulMaxAutotuneAlgorithmCount() {
   int64_t value;
   Status status =
@@ -57,29 +82,31 @@ int MatmulMaxAutotuneAlgorithmCount() {
 }
 
 StatusOr<se::blas::ComputationType> GetBlasComputationType(
-    const DataType& dtype) {
+    const se::blas::DataType& dtype) {
   using se::blas::ComputationType;
   static bool use_f32_for_f16_computation = MatmulDoFP32ComputationFP16Input();
   switch (dtype) {
-    case DT_HALF:
+    case se::blas::DataType::kHalf:
       return use_f32_for_f16_computation ? ComputationType::kF32
                                          : ComputationType::kF16;
-    case DT_BFLOAT16:
+    case se::blas::DataType::kBF16:
       return ComputationType::kF32;
-    case DT_FLOAT:  // fall-through
-    case DT_COMPLEX64:
+    case se::blas::DataType::kFloat:  // fall-through
+    case se::blas::DataType::kComplexFloat:
       return tensor_float_32_execution_enabled() ? ComputationType::kTF32AsF32
                                                  : ComputationType::kF32;
-    case DT_DOUBLE:  // fall-through
-    case DT_COMPLEX128:
+    case se::blas::DataType::kDouble:  // fall-through
+    case se::blas::DataType::kComplexDouble:
       return ComputationType::kF64;
     default:
       return errors::Internal("Unsupported dtype for Blas Plans.");
   }
 }
 
+}  // namespace
+
 StatusOr<const PlanAndAlgorithms*> GetPlanAndAlgorithms(
-    se::Stream* stream, const se::cuda::BlasLt::MatmulPlanParams& params,
+    se::Stream* stream, const BlasLtMatmulPlanParams& params,
     std::optional<int> max_algorithm_count) {
   static const int64_t max_scratch_size =
       GetWorkspaceLimit(1LL << 32);  // 4GB by default
@@ -95,13 +122,67 @@ StatusOr<const PlanAndAlgorithms*> GetPlanAndAlgorithms(
     se::cuda::BlasLt* blas_lt = se::cuda::GetBlasLt(stream);
     TF_RET_CHECK(blas_lt != nullptr);
 
-    se::cuda::BlasLt::MatmulPlan plan;
-    TF_RETURN_IF_ERROR(plan.init(params));
+    TF_ASSIGN_OR_RETURN(se::blas::ComputationType computation_type,
+                        GetBlasComputationType(params.dtype));
+
+    // cublas_lt's output is column-major. We want row-major so use identity:
+    // C^T = (A @ B)^T = B^T @ A^T.
+    constexpr auto kColMajor =
+        se::cuda::BlasLt::MatrixLayout::Order::kColumnMajor;
+
+    size_t rows_a = params.k;
+    size_t cols_a = params.m;
+    size_t rows_b = params.n;
+    size_t cols_b = params.k;
+
+    if (params.trans_a != se::blas::Transpose::kNoTranspose) {
+      std::swap(rows_a, cols_a);
+    }
+
+    if (params.trans_b != se::blas::Transpose::kNoTranspose) {
+      std::swap(rows_b, cols_b);
+    }
+
+    int64_t batch_stride_a =
+        params.broadcast_a ? 0 : static_cast<int64_t>(rows_a * cols_a);
+    int64_t batch_stride_b =
+        params.broadcast_b ? 0 : static_cast<int64_t>(rows_b * cols_b);
+
+    TF_ASSIGN_OR_RETURN(
+        auto a_desc,
+        se::cuda::BlasLt::MatrixLayout::Create(
+            params.dtype, rows_a, cols_a, kColMajor, params.batch_count,
+            /*leading_dim_stride=*/std::nullopt, batch_stride_a));
+    TF_ASSIGN_OR_RETURN(
+        auto b_desc,
+        se::cuda::BlasLt::MatrixLayout::Create(
+            params.dtype, rows_b, cols_b, kColMajor, params.batch_count,
+            /*leading_dim_stride=*/std::nullopt, batch_stride_b));
+    TF_ASSIGN_OR_RETURN(auto c_desc, se::cuda::BlasLt::MatrixLayout::Create(
+                                         params.dtype, params.n, params.m,
+                                         kColMajor, params.batch_count));
+    TF_ASSIGN_OR_RETURN(auto d_desc, se::cuda::BlasLt::MatrixLayout::Create(
+                                         params.dtype, params.n, params.m,
+                                         kColMajor, params.batch_count));
+
+    // `A` and `B` swapped (see above re. column-major output).
+    TF_ASSIGN_OR_RETURN(auto op_desc,
+                        se::cuda::BlasLt::MatmulDesc::Create(
+                            computation_type, /*scale_type=*/params.dtype,
+                            /*trans_a=*/params.trans_b,
+                            /*trans_b=*/params.trans_a, params.epilogue));
+
+    // `A` and `B` swapped (see above re. column-major output).
+    se::cuda::BlasLt::MatmulPlan plan{std::move(op_desc), std::move(b_desc),
+                                      std::move(a_desc), std::move(c_desc),
+                                      std::move(d_desc)};
+    TF_ASSIGN_OR_RETURN(
+        auto preference,
+        se::cuda::BlasLt::MatmulPreference::Create(max_scratch_size));
 
     TF_ASSIGN_OR_RETURN(
         std::vector<se::cuda::BlasLt::MatmulAlgorithm> algorithms,
-        blas_lt->GetMatmulAlgorithms(plan, max_scratch_size,
-                                     *max_algorithm_count));
+        blas_lt->GetMatmulAlgorithms(plan, preference, *max_algorithm_count));
 
     plan_and_algorithms =
         plan_map.Insert(params, {std::move(plan), std::move(algorithms)});

--- a/tensorflow/core/kernels/matmul_util.h
+++ b/tensorflow/core/kernels/matmul_util.h
@@ -21,15 +21,41 @@ limitations under the License.
 
 namespace tensorflow {
 
-// Reads the maximum number of algorithms for GEMM autotuning from the
-// environment variable TF_MATMUL_AUTOTUNE_MAX_ALGORITHMS. If no value is set,
-// return the default value.
-int MatmulMaxAutotuneAlgorithmCount();
-
 // Get a workspace limit from the environment variable, which is in MB.
 // Return the workspace memory limit in bytes. If no value is set, return the
 // default value.
 int64_t GetWorkspaceLimit(int64_t default_value_in_bytes);
+
+struct BlasLtMatmulPlanParams {
+  std::string ToString() const;
+  bool operator==(const BlasLtMatmulPlanParams& other) const;
+
+  se::blas::DataType dtype;
+  size_t m;
+  size_t n;
+  size_t k;
+  se::blas::Transpose trans_a;
+  se::blas::Transpose trans_b;
+  size_t batch_count = 1;
+  bool broadcast_a = false;
+  bool broadcast_b = false;
+  se::cuda::BlasLt::Epilogue epilogue = se::cuda::BlasLt::Epilogue::kDefault;
+};
+
+namespace internal {
+
+inline auto AsTuple(const BlasLtMatmulPlanParams& p) {
+  return std::make_tuple(p.dtype, p.m, p.n, p.k, p.trans_a, p.trans_b,
+                         p.batch_count, p.broadcast_a, p.broadcast_b,
+                         p.epilogue);
+}
+
+}  // namespace internal
+
+template <typename H>
+H AbslHashValue(H h, const BlasLtMatmulPlanParams& params) {
+  return H::combine(std::move(h), internal::AsTuple(params));
+}
 
 struct PlanAndAlgorithms {
   se::cuda::BlasLt::MatmulPlan plan;
@@ -40,26 +66,13 @@ struct PlanAndAlgorithms {
 // algorithms.
 class BlasLtMatmulPlanMap {
  public:
-  const PlanAndAlgorithms* Find(
-      const se::cuda::BlasLt::MatmulPlanParams& params) const {
-    absl::MutexLock lock(&mu_);
-    auto iter = params_plan_map_.find(params);
-    if (iter == params_plan_map_.end()) {
-      return nullptr;
-    }
-    return &iter->second;
-  }
-
-  const PlanAndAlgorithms* Insert(
-      const se::cuda::BlasLt::MatmulPlanParams& params,
-      PlanAndAlgorithms value) {
-    absl::MutexLock lock(&mu_);
-    return &params_plan_map_.emplace(params, std::move(value)).first->second;
-  }
+  const PlanAndAlgorithms* Find(const BlasLtMatmulPlanParams& params) const;
+  const PlanAndAlgorithms* Insert(const BlasLtMatmulPlanParams& params,
+                                  PlanAndAlgorithms value);
 
  private:
   mutable absl::Mutex mu_;
-  absl::flat_hash_map<se::cuda::BlasLt::MatmulPlanParams, PlanAndAlgorithms>
+  absl::flat_hash_map<BlasLtMatmulPlanParams, PlanAndAlgorithms>
       params_plan_map_ ABSL_GUARDED_BY(mu_);
 };
 
@@ -67,7 +80,7 @@ StatusOr<se::blas::ComputationType> GetBlasComputationType(
     const DataType& dtype);
 
 StatusOr<const PlanAndAlgorithms*> GetPlanAndAlgorithms(
-    se::Stream* stream, const se::cuda::BlasLt::MatmulPlanParams& params,
+    se::Stream* stream, const BlasLtMatmulPlanParams& params,
     std::optional<int> max_algorithm_count = std::nullopt);
 
 }  // namespace tensorflow

--- a/tensorflow/stream_executor/cuda/BUILD
+++ b/tensorflow/stream_executor/cuda/BUILD
@@ -307,6 +307,7 @@ cc_library(
         "@com_google_absl//absl/synchronization",
         "//third_party/eigen3",
         "@local_config_cuda//cuda:cuda_headers",
+        "//tensorflow/compiler/xla:status_macros",
         "//tensorflow/core/platform:tensor_float_32_hdr_lib",
         "//tensorflow/core/platform:thread_annotations",
         "//tensorflow/stream_executor:device_memory",

--- a/tensorflow/stream_executor/cuda/cuda_blas_lt.cc
+++ b/tensorflow/stream_executor/cuda/cuda_blas_lt.cc
@@ -15,13 +15,17 @@ limitations under the License.
 
 #include "tensorflow/stream_executor/cuda/cuda_blas_lt.h"
 
+#include <algorithm>
+#include <climits>
+#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "third_party/gpus/cuda/include/cublasLt.h"
 #include "third_party/gpus/cuda/include/cublas_v2.h"
-#include "third_party/gpus/cuda/include/cuda.h"
+#include "tensorflow/compiler/xla/status_macros.h"
 #include "tensorflow/stream_executor/blas.h"
 #include "tensorflow/stream_executor/cuda/cuda_blas.h"
 #include "tensorflow/stream_executor/cuda/cuda_blas_utils.h"
@@ -32,16 +36,49 @@ limitations under the License.
 #include "tensorflow/stream_executor/scratch_allocator.h"
 #include "tensorflow/stream_executor/stream.h"
 
+#define SET_ATTR(setter, handle, attr, value) \
+  ToStatus(setter(handle, attr, &value, sizeof(decltype(value))), #setter)
+
+#define GET_ATTR(getter, handle, attr, ValueT)                            \
+  [&]() -> port::StatusOr<ValueT> {                                       \
+    ValueT value;                                                         \
+    TF_RETURN_IF_ERROR(ToStatus(                                          \
+        getter(handle, attr, &value, sizeof(ValueT), nullptr), #getter)); \
+    return std::move(value);                                              \
+  }()
+
 namespace stream_executor {
 namespace cuda {
 namespace {
 
-blas::DataType GetScaleType(blas::DataType c_type,
-                            blas::ComputationType compute_type) {
-  return ((compute_type == blas::ComputationType::kF32) &&
-          (c_type != blas::DataType::kComplexFloat))
-             ? blas::DataType::kFloat
-             : c_type;
+template <typename T>
+port::Status SetAttr(cublasLtMatrixLayout_t handle,
+                     cublasLtMatrixLayoutAttribute_t attr, T value) {
+  return SET_ATTR(cublasLtMatrixLayoutSetAttribute, handle, attr, value);
+}
+
+template <typename T>
+port::StatusOr<T> GetAttr(cublasLtMatrixLayout_t handle,
+                          cublasLtMatrixLayoutAttribute_t attr) {
+  return GET_ATTR(cublasLtMatrixLayoutGetAttribute, handle, attr, T);
+}
+
+template <typename T>
+port::Status SetAttr(cublasLtMatmulDesc_t handle,
+                     cublasLtMatmulDescAttributes_t attr, T value) {
+  return SET_ATTR(cublasLtMatmulDescSetAttribute, handle, attr, value);
+}
+
+template <typename T>
+port::StatusOr<T> GetAttr(cublasLtMatmulDesc_t handle,
+                          cublasLtMatmulDescAttributes_t attr) {
+  return GET_ATTR(cublasLtMatmulDescGetAttribute, handle, attr, T);
+}
+
+template <typename T>
+port::Status SetAttr(cublasLtMatmulPreference_t handle,
+                     cublasLtMatmulPreferenceAttributes_t attr, T value) {
+  return SET_ATTR(cublasLtMatmulPreferenceSetAttribute, handle, attr, value);
 }
 
 cublasLtPointerMode_t AsCublasLtPointerMode(BlasLt::PointerMode pointer_mode) {
@@ -66,214 +103,6 @@ cublasLtEpilogue_t AsCublasLtEpilogue(BlasLt::Epilogue epilogue) {
   }
 }
 
-template <typename T>
-inline port::Status SetCublasLtAttr(cublasLtMatrixLayout_t handle,
-                                    cublasLtMatrixLayoutAttribute_t attr,
-                                    const T &value) {
-  cublasStatus_t status =
-      cublasLtMatrixLayoutSetAttribute(handle, attr, &value, sizeof(T));
-  if (status != CUBLAS_STATUS_SUCCESS) {
-    return port::Status(
-        port::error::INTERNAL,
-        absl::StrCat("cublasLtMatrixLayoutSetAttribute(attr=", attr,
-                     ", value=", value, ") failed: ", ToString(status)));
-  }
-  return port::Status::OK();
-}
-
-template <typename T>
-inline port::Status SetCublasLtAttr(cublasLtMatmulAlgo_t *handle,
-                                    cublasLtMatmulAlgoConfigAttributes_t attr,
-                                    const T &value) {
-  cublasStatus_t status =
-      cublasLtMatmulAlgoConfigSetAttribute(handle, attr, &value, sizeof(T));
-  if (status != CUBLAS_STATUS_SUCCESS) {
-    return port::Status(
-        port::error::INTERNAL,
-        absl::StrCat("cublasLtMatmulAlgoConfigSetAttribute(attr=", attr,
-                     ", value=", value, ") failed: ", ToString(status)));
-  }
-  return port::Status::OK();
-}
-
-template <typename T>
-inline port::Status SetCublasLtAttr(cublasLtMatmulPreference_t handle,
-                                    cublasLtMatmulPreferenceAttributes_t attr,
-                                    const T &value) {
-  cublasStatus_t status =
-      cublasLtMatmulPreferenceSetAttribute(handle, attr, &value, sizeof(value));
-  if (status != CUBLAS_STATUS_SUCCESS) {
-    return port::Status(
-        port::error::INTERNAL,
-        absl::StrCat("cublasLtMatmulPreferenceSetAttribute(attr=", attr,
-                     ", value=", value, ") failed: ", ToString(status)));
-  }
-  return port::Status::OK();
-}
-
-template <typename T>
-inline bool GetCublasLtAttr(const cublasLtMatmulAlgo_t *handle,
-                            cublasLtMatmulAlgoConfigAttributes_t attr,
-                            T *value) {
-  auto mutable_handle = const_cast<cublasLtMatmulAlgo_t *>(handle);
-  size_t bytes_written = 0;
-  return cublasLtMatmulAlgoConfigGetAttribute(mutable_handle, attr, value,
-                                              sizeof(T), &bytes_written) ==
-             CUBLAS_STATUS_SUCCESS &&
-         bytes_written == sizeof(T);
-}
-
-template <typename T>
-inline const T &ValueForStrCat(const T &value) {
-  return value;
-}
-template <typename T>
-inline absl::Hex ValueForStrCat(T *ptr) {
-  return absl::Hex(reinterpret_cast<uintptr_t>(ptr));
-}
-
-template <typename T>
-inline port::Status SetCublasLtAttr(cublasLtMatmulDesc_t handle,
-                                    cublasLtMatmulDescAttributes_t attr,
-                                    const T &value) {
-  cublasStatus_t status =
-      cublasLtMatmulDescSetAttribute(handle, attr, &value, sizeof(value));
-  if (status != CUBLAS_STATUS_SUCCESS) {
-    return port::Status(
-        port::error::INTERNAL,
-        absl::StrCat("cublasLtMatmulDescSetAttribute(attr=", attr, ", value=",
-                     ValueForStrCat(value), ") failed: ", ToString(status)));
-  }
-  return port::Status::OK();
-}
-
-port::StatusOr<BlasLt::UniqueOpDesc> CreateCublasLtOperationDesc(
-    blas::ComputationType computation_type, blas::DataType scale_type,
-    BlasLt::PointerMode pointer_mode, BlasLt::Epilogue epilogue,
-    blas::Transpose transa, blas::Transpose transb) {
-  cublasLtMatmulDesc_t desc;
-  cublasComputeType_t cublas_compute_type =
-      AsCublasComputeType(computation_type);
-  cudaDataType_t cuda_scale_type = AsCudaDataType(scale_type);
-  cublasStatus_t status =
-      cublasLtMatmulDescCreate(&desc, cublas_compute_type, cuda_scale_type);
-  if (status != CUBLAS_STATUS_SUCCESS) {
-    return port::Status(
-        port::error::INTERNAL,
-        absl::StrCat("cublasLtMatmulDescCreate(computation_type=",
-                     computation_type, ") failed: ", ToString(status)));
-  }
-  BlasLt::UniqueOpDesc unique_desc(desc);
-  TF_RETURN_IF_ERROR(SetCublasLtAttr(desc, CUBLASLT_MATMUL_DESC_POINTER_MODE,
-                                     AsCublasLtPointerMode(pointer_mode)));
-  TF_RETURN_IF_ERROR(SetCublasLtAttr(desc, CUBLASLT_MATMUL_DESC_EPILOGUE,
-                                     AsCublasLtEpilogue(epilogue)));
-  TF_RETURN_IF_ERROR(SetCublasLtAttr(desc, CUBLASLT_MATMUL_DESC_TRANSA,
-                                     AsCublasOperation(transa)));
-  TF_RETURN_IF_ERROR(SetCublasLtAttr(desc, CUBLASLT_MATMUL_DESC_TRANSB,
-                                     AsCublasOperation(transb)));
-  return unique_desc;
-}
-
-port::StatusOr<BlasLt::UniqueLayoutDesc> CreateCublasLtLayoutDesc(
-    blas::DataType data_type, uint64_t rows, uint64 cols, int64_t ld,
-    int64_t stride, int batch_count) {
-  cublasLtMatrixLayout_t desc;
-  cublasStatus_t status = cublasLtMatrixLayoutCreate(
-      &desc, AsCudaDataType(data_type), rows, cols, ld);
-  if (status != CUBLAS_STATUS_SUCCESS) {
-    return port::Status(
-        port::error::INTERNAL,
-        absl::StrCat("cublasLtMatrixLayoutCreate failed: ", ToString(status)));
-  }
-  BlasLt::UniqueLayoutDesc unique_desc(desc);
-  TF_RETURN_IF_ERROR(
-      SetCublasLtAttr(desc, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, batch_count));
-  TF_RETURN_IF_ERROR(SetCublasLtAttr(
-      desc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, stride));
-  return unique_desc;
-}
-
-size_t GetDataTypeSizeBytes(blas::DataType ty) {
-  switch (ty) {
-    case blas::DataType::kHalf:
-      return 2;
-    case blas::DataType::kFloat:
-      return 4;
-    case blas::DataType::kDouble:
-      return 8;
-    case blas::DataType::kInt8:
-      return 1;
-    case blas::DataType::kInt32:
-      return 4;
-    case blas::DataType::kComplexFloat:
-      return 8;
-    case blas::DataType::kComplexDouble:
-      return 16;
-    default:
-      LOG(FATAL) << "Invalid value of blas::DataType in GetDataTypeSizeBytes";
-  }
-}
-
-port::StatusOr<BlasLt::UniqueMatmulPreference> CreateCublasLtMatmulPreference(
-    const BlasLt::MatmulPlan &plan, size_t max_workspace_bytes) {
-  cublasLtMatmulPreference_t preference;
-  cublasStatus_t status = cublasLtMatmulPreferenceCreate(&preference);
-  if (status != CUBLAS_STATUS_SUCCESS) {
-    return port::Status(port::error::INTERNAL,
-                        absl::StrCat("cublasLtMatmulPreferenceCreate failed: ",
-                                     ToString(status)));
-  }
-  BlasLt::UniqueMatmulPreference unique_preference(preference);
-  TF_RETURN_IF_ERROR(SetCublasLtAttr(preference,
-                                     CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
-                                     max_workspace_bytes));
-
-  if (plan.params().batch_count == 0) {
-    return unique_preference;
-  }
-  // This is a workaround for a known issue in cuBlasLt where the heuristic may
-  // in rare cases select an algo that does not support the specified stride.
-  // Specifying the alignment requirements manually like this avoids the issue.
-  auto get_alignment_bytes = [](int64_t stride, blas::DataType dtype) {
-    return (stride & -stride) * GetDataTypeSizeBytes(dtype);
-  };
-  if (plan.params().stride_a) {
-    TF_RETURN_IF_ERROR(
-        SetCublasLtAttr(preference, CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_A_BYTES,
-                        (uint32)get_alignment_bytes(plan.params().stride_a,
-                                                    plan.params().ab_type)));
-  }
-  if (plan.params().stride_b) {
-    TF_RETURN_IF_ERROR(
-        SetCublasLtAttr(preference, CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_B_BYTES,
-                        (uint32)get_alignment_bytes(plan.params().stride_b,
-                                                    plan.params().ab_type)));
-  }
-  if (plan.params().stride_c) {
-    TF_RETURN_IF_ERROR(
-        SetCublasLtAttr(preference, CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_C_BYTES,
-                        (uint32)get_alignment_bytes(plan.params().stride_c,
-                                                    plan.params().c_type)));
-  }
-  if (plan.params().stride_c) {
-    TF_RETURN_IF_ERROR(
-        SetCublasLtAttr(preference, CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_D_BYTES,
-                        (uint32)get_alignment_bytes(plan.params().stride_c,
-                                                    plan.params().c_type)));
-  }
-  return unique_preference;
-}
-
-port::Status AllocateWorkspace(void **workspace,
-                               ScratchAllocator *scratch_allocator,
-                               size_t num_bytes) {
-  TF_ASSIGN_OR_RETURN(DeviceMemory<uint8_t> workspace_bytes,
-                      scratch_allocator->AllocateBytes(num_bytes));
-  *workspace = (void *)gpu::GpuMemoryMutable(&workspace_bytes);
-  return port::Status::OK();
-}
-
 }  // namespace
 
 port::Status BlasLt::Init() {
@@ -284,344 +113,179 @@ port::Status BlasLt::Init() {
   return port::Status::OK();
 }
 
-std::string BlasLt::MatmulPlanParams::ToString() const {
-  return absl::StrCat(transa, ", ", transb, ", ", m, ", ", n, ", ", k, ", ",
-                      batch_count, ", ", ab_type, ", ", epilogue);
-}
-
-int BlasLt::MatmulAlgorithm::algo_id() const {
-  int id;
-  GetCublasLtAttr(&algo_, CUBLASLT_ALGO_CONFIG_ID, &id);
-  return id;
-}
-
-port::Status BlasLt::MatmulPlan::init(const MatmulPlanParams &p) {
-  params_ = p;
-  scale_type_ = GetScaleType(p.c_type, p.computation_type);
-  TF_ASSIGN_OR_RETURN(
-      op_desc_,
-      CreateCublasLtOperationDesc(
-          p.computation_type, GetScaleType(p.c_type, p.computation_type),
-          p.pointer_mode, p.epilogue, p.transa, p.transb));
-  uint64_t rows_a = p.transa == blas::Transpose::kNoTranspose ? p.m : p.k;
-  uint64_t cols_a = p.transa == blas::Transpose::kNoTranspose ? p.k : p.m;
-  uint64_t rows_b = p.transb == blas::Transpose::kNoTranspose ? p.k : p.n;
-  uint64_t cols_b = p.transb == blas::Transpose::kNoTranspose ? p.n : p.k;
-  TF_ASSIGN_OR_RETURN(
-      a_desc_, CreateCublasLtLayoutDesc(p.ab_type, rows_a, cols_a, p.lda,
-                                        p.stride_a, capped_batch_count()));
-  TF_ASSIGN_OR_RETURN(
-      b_desc_, CreateCublasLtLayoutDesc(p.ab_type, rows_b, cols_b, p.ldb,
-                                        p.stride_b, capped_batch_count()));
-  TF_ASSIGN_OR_RETURN(
-      c_desc_, CreateCublasLtLayoutDesc(p.c_type, p.m, p.n, p.ldc, p.stride_c,
-                                        capped_batch_count()));
-  TF_ASSIGN_OR_RETURN(
-      d_desc_, CreateCublasLtLayoutDesc(p.c_type, p.m, p.n, p.ldc, p.stride_c,
-                                        capped_batch_count()));
-  remainder_batch_count_ =
-      p.batch_count > kMaxBatchCount ? p.batch_count % kMaxBatchCount : 0;
-  if (remainder_batch_count_) {
-    TF_ASSIGN_OR_RETURN(
-        a_remainder_desc_,
-        CreateCublasLtLayoutDesc(p.ab_type, rows_a, cols_a, p.lda, p.stride_a,
-                                 remainder_batch_count_));
-    TF_ASSIGN_OR_RETURN(
-        b_remainder_desc_,
-        CreateCublasLtLayoutDesc(p.ab_type, rows_b, cols_b, p.ldb, p.stride_b,
-                                 remainder_batch_count_));
-    TF_ASSIGN_OR_RETURN(
-        c_remainder_desc_,
-        CreateCublasLtLayoutDesc(p.c_type, p.m, p.n, p.ldc, p.stride_c,
-                                 remainder_batch_count_));
-    TF_ASSIGN_OR_RETURN(
-        d_remainder_desc_,
-        CreateCublasLtLayoutDesc(p.c_type, p.m, p.n, p.ldc, p.stride_c,
-                                 remainder_batch_count_));
+/*static*/ port::StatusOr<BlasLt::MatrixLayout> BlasLt::MatrixLayout::Create(
+    blas::DataType type, size_t num_rows, size_t num_cols,
+    BlasLt::MatrixLayout::Order order, size_t batch_size,
+    std::optional<int64_t> leading_dim_stride,
+    std::optional<int64_t> batch_stride) {
+  if (!leading_dim_stride) {
+    leading_dim_stride = (order == Order::kRowMajor) ? num_cols : num_rows;
   }
-  return port::Status::OK();
+
+  cublasLtMatrixLayout_t cu_layout;
+  SE_CUBLAS_RETURN_IF_ERROR(
+      cublasLtMatrixLayoutCreate(&cu_layout, AsCudaDataType(type), num_rows,
+                                 num_cols, *leading_dim_stride));
+  // Wrap cublas handle immediately, so it is cleaned up if an error occurs.
+  BlasLt::MatrixLayout layout(cu_layout);
+  TF_RETURN_IF_ERROR(
+      SetAttr(cu_layout, CUBLASLT_MATRIX_LAYOUT_ORDER,
+              int32_t{(order == Order::kRowMajor) ? CUBLASLT_ORDER_ROW
+                                                  : CUBLASLT_ORDER_COL}));
+  TF_RETURN_IF_ERROR(SetAttr(cu_layout, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT,
+                             static_cast<int32_t>(batch_size)));
+
+  if (!batch_stride) {
+    batch_stride = (batch_size > 1) ? num_rows * num_cols : 0;
+  }
+
+  TF_RETURN_IF_ERROR(SetAttr(
+      cu_layout, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, *batch_stride));
+  return std::move(layout);
 }
 
-bool BlasLt::MatmulPlan::SetBiasPointer(const void *bias) const {
-  return SetCublasLtAttr(op_desc_.get(), CUBLASLT_MATMUL_DESC_BIAS_POINTER,
-                         bias)
-      .ok();
+cudaDataType_t BlasLt::MatrixLayout::type() const {
+  return static_cast<cudaDataType_t>(
+      GetAttr<uint32_t>(handle_.get(), CUBLASLT_MATRIX_LAYOUT_TYPE)
+          .ValueOrDie());
 }
 
-/*static*/ port::StatusOr<BlasLt::MatmulPlan> BlasLt::CreateMatmulPlan(
-    const BlasLt::MatmulPlanParams &p) {
-  MatmulPlan cuda_plan;
-  TF_RETURN_IF_ERROR(cuda_plan.init(p));
-  return std::move(cuda_plan);
+/*static*/ port::StatusOr<BlasLt::MatmulDesc> BlasLt::MatmulDesc::Create(
+    blas::ComputationType compute_type, blas::DataType scale_type,
+    blas::Transpose trans_a, blas::Transpose trans_b, BlasLt::Epilogue epilogue,
+    BlasLt::PointerMode pointer_mode) {
+  cublasLtMatmulDesc_t cu_desc;
+  SE_CUBLAS_RETURN_IF_ERROR(cublasLtMatmulDescCreate(
+      &cu_desc, AsCublasComputeType(compute_type), AsCudaDataType(scale_type)));
+  // Wrap cublas handle immediately, so it is cleaned up if an error occurs.
+  BlasLt::MatmulDesc desc(cu_desc);
+  TF_RETURN_IF_ERROR(SetAttr(cu_desc, CUBLASLT_MATMUL_DESC_POINTER_MODE,
+                             AsCublasLtPointerMode(pointer_mode)));
+  TF_RETURN_IF_ERROR(SetAttr(cu_desc, CUBLASLT_MATMUL_DESC_TRANSA,
+                             AsCublasOperation(trans_a)));
+  TF_RETURN_IF_ERROR(SetAttr(cu_desc, CUBLASLT_MATMUL_DESC_TRANSB,
+                             AsCublasOperation(trans_b)));
+  TF_RETURN_IF_ERROR(SetAttr(cu_desc, CUBLASLT_MATMUL_DESC_EPILOGUE,
+                             AsCublasLtEpilogue(epilogue)));
+  return std::move(desc);
+}
+
+cublasComputeType_t BlasLt::MatmulDesc::compute_type() const {
+  return static_cast<cublasComputeType_t>(
+      GetAttr<int32_t>(handle_.get(), CUBLASLT_MATMUL_DESC_COMPUTE_TYPE)
+          .ValueOrDie());
+}
+
+cudaDataType_t BlasLt::MatmulDesc::scale_type() const {
+  return static_cast<cudaDataType_t>(
+      GetAttr<int32_t>(handle_.get(), CUBLASLT_MATMUL_DESC_SCALE_TYPE)
+          .ValueOrDie());
+}
+
+cublasLtPointerMode_t BlasLt::MatmulDesc::pointer_mode() const {
+  return static_cast<cublasLtPointerMode_t>(
+      GetAttr<int32_t>(handle_.get(), CUBLASLT_MATMUL_DESC_POINTER_MODE)
+          .ValueOrDie());
+}
+
+/*static*/ port::StatusOr<BlasLt::MatmulPreference>
+BlasLt::MatmulPreference::Create(size_t max_workspace_size) {
+  cublasLtMatmulPreference_t cu_preference;
+  SE_CUBLAS_RETURN_IF_ERROR(cublasLtMatmulPreferenceCreate(&cu_preference));
+  // Wrap cublas handle immediately, so it is cleaned up if an error occurs.
+  BlasLt::MatmulPreference preference(cu_preference);
+  TF_RETURN_IF_ERROR(SetAttr<uint64_t>(cu_preference,
+                                       CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+                                       max_workspace_size));
+  return std::move(preference);
 }
 
 port::StatusOr<std::vector<BlasLt::MatmulAlgorithm>>
-BlasLt::GetMatmulAlgorithmsInternal(const BlasLt::MatmulPlan &plan,
-                                    size_t max_workspace_size,
-                                    int max_algorithm_count,
-                                    bool for_remainder_batch) {
-  TF_ASSIGN_OR_RETURN(UniqueMatmulPreference preference,
-                      CreateCublasLtMatmulPreference(plan, max_workspace_size));
-
+BlasLt::GetMatmulAlgorithms(const BlasLt::MatmulPlan& plan,
+                            const BlasLt::MatmulPreference& preference,
+                            size_t max_algorithm_count) {
+  max_algorithm_count = std::min(max_algorithm_count, size_t{INT_MAX});
   std::vector<cublasLtMatmulHeuristicResult_t> results(max_algorithm_count);
   {
     absl::MutexLock lock(&mu_);
-
-    CHECK(blas_lt_ != nullptr);
+    TF_RET_CHECK(blas_lt_ != nullptr);
 
     gpu::ScopedActivateExecutorContext sac{parent_};
 
     int found_algorithm_count = 0;
-    const auto &a_desc =
-        for_remainder_batch ? plan.a_remainder_desc() : plan.a_desc();
-    const auto &b_desc =
-        for_remainder_batch ? plan.b_remainder_desc() : plan.b_desc();
-    const auto &c_desc =
-        for_remainder_batch ? plan.c_remainder_desc() : plan.c_desc();
-    const auto &d_desc =
-        for_remainder_batch ? plan.d_remainder_desc() : plan.d_desc();
-    cublasStatus_t status = cublasLtMatmulAlgoGetHeuristic(
-        blas_lt_.get(), plan.op_desc(), a_desc, b_desc, c_desc, d_desc,
+    SE_CUBLAS_RETURN_IF_ERROR(cublasLtMatmulAlgoGetHeuristic(
+        blas_lt_.get(), plan.op_desc.get(), plan.a_desc.get(),
+        plan.b_desc.get(), plan.c_desc.get(), plan.d_desc.get(),
         preference.get(), max_algorithm_count, results.data(),
-        &found_algorithm_count);
-    if (status != CUBLAS_STATUS_SUCCESS) {
-      return port::Status(
-          port::error::INTERNAL,
-          absl::StrCat("cublasLtMatmulAlgoGetHeuristic failed: ",
-                       ToString(status)));
-    }
+        &found_algorithm_count));
     results.resize(found_algorithm_count);
   }
 
-  std::vector<MatmulAlgorithm> out_algorithms;
-  out_algorithms.reserve(results.size());
-  for (size_t i = 0; i < results.size(); ++i) {
-    const auto &result = results[i];
-    if (result.state != CUBLAS_STATUS_SUCCESS) continue;  // Skip failed algos
-    out_algorithms.emplace_back(i, result.algo, result.workspaceSize);
+  std::vector<BlasLt::MatmulAlgorithm> algorithms;
+  algorithms.reserve(results.size());
+  for (const cublasLtMatmulHeuristicResult_t& result : results) {
+    if (result.state == CUBLAS_STATUS_SUCCESS) {  // Skip failed algos.
+      algorithms.push_back({result.algo, result.workspaceSize});
+    }
   }
-  return out_algorithms;
+  return std::move(algorithms);
 }
 
-port::StatusOr<std::vector<BlasLt::MatmulAlgorithm>>
-BlasLt::GetMatmulAlgorithms(const BlasLt::MatmulPlan &plan,
-                            size_t max_workspace_size,
-                            int max_algorithm_count) {
-  return GetMatmulAlgorithmsInternal(plan, max_workspace_size,
-                                     max_algorithm_count);
-}
-
-bool BlasLt::DoMatmulInternal(
-    Stream *stream, bool err_on_failure, const BlasLt::MatmulPlan &plan,
-    const HostOrDeviceScalar<void> &alpha, DeviceMemoryBase a,
-    DeviceMemoryBase b, const HostOrDeviceScalar<void> &beta,
-    DeviceMemoryBase c, DeviceMemoryBase d, ScratchAllocator *scratch_allocator,
-    const BlasLt::MatmulAlgorithm &algorithm, DeviceMemoryBase bias) {
-  if (alpha.data_type() != plan.scale_type() ||
-      beta.data_type() != plan.scale_type()) {
-    VLOG(2) << "DoBlasLtMatmul returning false because alpha and beta types do "
-               "not match plan: expected "
-            << plan.c_type() << ", got alpha=" << alpha.data_type()
-            << " beta=" << beta.data_type();
-    return false;
-  }
-  if (alpha.is_pointer() != beta.is_pointer()) {
-    VLOG(2) << "DoBlasLtMatmul returning false because one of `alpha` "
-               "and `beta` is a pointer, but the other is not.";
-    return false;
-  }
-  bool is_pointer_mode_host = !alpha.is_pointer();
-  if ((plan.params().pointer_mode == PointerMode::kHost) !=
-      is_pointer_mode_host) {
-    VLOG(2) << "DoBlasLtMatmul returning false because plan has wrong "
-               "pointer_mode for the given alpha/beta.";
-    return false;
-  }
-  if ((plan.params().epilogue == Epilogue::kBias ||
-       plan.params().epilogue == Epilogue::kBiasThenReLU) !=
-      (bias != nullptr)) {
-    VLOG(2) << "DoBlasLtMatmul returning false because plan has wrong "
-               "epilogue for the given bias pointer.";
-    return false;
-  }
-  const void *alpha_ptr = alpha.is_pointer() ? alpha.opaque_pointer().opaque()
-                                             : alpha.opaque_value();
-  const void *beta_ptr =
-      beta.is_pointer() ? beta.opaque_pointer().opaque() : beta.opaque_value();
-
-  void *workspace = nullptr;
-  if (algorithm.workspace_size()) {
-    port::Status allocation_status = AllocateWorkspace(
-        &workspace, scratch_allocator, algorithm.workspace_size());
-    if (!allocation_status.ok()) {
-      if (err_on_failure || VLOG_IS_ON(3)) {
-        LOG(ERROR)
-            << "Failed to allocate workspace for cublasLtMatmul algo with id: "
-            << algorithm.algo_id() << " requiring "
-            << algorithm.workspace_size() << " bytes of workspace";
-      }
-      return false;
-    }
-  }
-
-  // This is only used when batch_count > kMaxBatchCount.
-  std::optional<MatmulAlgorithm> remainder_algo;
-  if (plan.remainder_batch_count()) {
-    // There is no easy way to get the user-specified max workspace size here,
-    // so we just allow a very small amount and don't worry too much about
-    // performance because this is only used in rare cases. The same reasoning
-    // applies to selection of the algorithm.
-    size_t max_workspace_size = 4 * 1024 * 1024;  // 4 MiB
-    auto status_or_algorithms =
-        GetMatmulAlgorithmsInternal(plan, max_workspace_size,
-                                    /* max_algorithm_count = */ 1,
-                                    /* for_remainder_batch = */ true);
-    if (!status_or_algorithms.ok()) {
-      if (err_on_failure || VLOG_IS_ON(3)) {
-        LOG(ERROR) << "Failed to get algorithms for blasLt remainder batch.";
-      }
-      return false;
-    }
-    auto algorithms = std::move(status_or_algorithms).value();
-    remainder_algo = algorithms.front();
-  }
-
-  cudaStream_t cuda_stream = gpu::AsGpuStreamValue(stream);
-
-  absl::MutexLock lock(&mu_);
-
-  if (bias != nullptr) {
-    if (!plan.SetBiasPointer(bias.opaque())) {
-      VLOG(2) << "DoBlasLtMatmul returning false because setting the bias "
-                 "pointer failed.";
-      return false;
-    }
-  }
-
-  CHECK(blas_lt_ != nullptr);
-
-  gpu::ScopedActivateExecutorContext sac{parent_};
-
-  // Plan execution is broken down into repeat calls with capped_batch_count,
-  // followed by a final call with remainder_batch_count.
-  // Cases where batch_count <= kMaxBatchCount require only a single call (a
-  // single loop iteration and no remainder).
-  int ab_type_size = GetDataTypeSizeBytes(plan.params().ab_type);
-  int c_type_size = GetDataTypeSizeBytes(plan.params().c_type);
-  const char *a_ptr = static_cast<const char *>(a.opaque());
-  const char *b_ptr = static_cast<const char *>(b.opaque());
-  const char *c_ptr = static_cast<const char *>(c.opaque());
-  char *d_ptr = static_cast<char *>(d.opaque());
-  int capped_batch_count = plan.capped_batch_count();
-  for (int batch = 0; batch + capped_batch_count <= plan.params().batch_count;
-       batch += capped_batch_count) {
-    cublasStatus_t ret = cublasLtMatmul(
-        blas_lt_.get(), plan.op_desc(), alpha_ptr, a_ptr, plan.a_desc(), b_ptr,
-        plan.b_desc(), beta_ptr, c_ptr, plan.c_desc(), d_ptr, plan.d_desc(),
-        algorithm.algo(), workspace, algorithm.workspace_size(), cuda_stream);
-    if (ret != CUBLAS_STATUS_SUCCESS) {
-      if (err_on_failure || VLOG_IS_ON(3)) {
-        LOG(ERROR) << "failed to run cublasLtMatmul routine: " << ToString(ret);
-      }
-      return false;
-    }
-    a_ptr += capped_batch_count * plan.params().stride_a * ab_type_size;
-    b_ptr += capped_batch_count * plan.params().stride_b * ab_type_size;
-    c_ptr += capped_batch_count * plan.params().stride_c * c_type_size;
-    d_ptr += capped_batch_count * plan.params().stride_c * c_type_size;
-  }
-  // This is only used when batch_count > kMaxBatchCount.
-  if (plan.remainder_batch_count()) {
-    if (remainder_algo->workspace_size()) {
-      port::Status allocation_status = AllocateWorkspace(
-          &workspace, scratch_allocator, remainder_algo->workspace_size());
-      if (!allocation_status.ok()) {
-        if (err_on_failure || VLOG_IS_ON(3)) {
-          LOG(ERROR) << "Failed to allocate workspace for cublasLtMatmul algo "
-                        "with id: "
-                     << remainder_algo->algo_id() << " requiring "
-                     << remainder_algo->workspace_size()
-                     << " bytes of workspace";
-        }
-        return false;
-      }
-    }
-    cublasStatus_t ret = cublasLtMatmul(
-        blas_lt_.get(), plan.op_desc(), alpha_ptr, a_ptr,
-        plan.a_remainder_desc(), b_ptr, plan.b_remainder_desc(), beta_ptr,
-        c_ptr, plan.c_remainder_desc(), d_ptr, plan.d_remainder_desc(),
-        remainder_algo->algo(), workspace, remainder_algo->workspace_size(),
-        cuda_stream);
-    if (ret != CUBLAS_STATUS_SUCCESS) {
-      if (err_on_failure || VLOG_IS_ON(3)) {
-        LOG(ERROR) << "failed to run remainder cublasLtMatmul routine: "
-                   << ToString(ret);
-      }
-      return false;
-    }
-  }
-  return true;
-}
-
-bool BlasLt::DoMatmul(Stream *stream, const BlasLt::MatmulPlan &plan,
-                      const HostOrDeviceScalar<void> &alpha, DeviceMemoryBase a,
-                      DeviceMemoryBase b, const HostOrDeviceScalar<void> &beta,
-                      DeviceMemoryBase c, ScratchAllocator *scratch_allocator,
-                      const BlasLt::MatmulAlgorithm &algorithm,
-                      DeviceMemoryBase bias,
-                      blas::ProfileResult *output_profile_result) {
-  HostOrDeviceScalar<void> alpha_cast = alpha;
-  HostOrDeviceScalar<void> beta_cast = beta;
-  if (plan.c_type() == blas::DataType::kHalf &&
-      plan.scale_type() == blas::DataType::kFloat) {
-    // The given alpha and beta types are F16 (they always match c), but F32*
-    // computation type requires that they be F32, so we must cast them.
-    if (alpha.is_pointer() || beta.is_pointer()) {
-      // We cannot easily convert a pointer to f16 memory to a pointer to f32
-      // memory from here, so we don't support this for now.
-      return false;
-    }
-    alpha_cast = HostOrDeviceScalar<void>(
-        static_cast<float>(alpha.value<Eigen::half>()));
-    beta_cast =
-        HostOrDeviceScalar<void>(static_cast<float>(beta.value<Eigen::half>()));
-  }
-
+port::Status BlasLt::DoMatmul(Stream* stream, const BlasLt::MatmulPlan& plan,
+                              const void* alpha, DeviceMemoryBase a,
+                              DeviceMemoryBase b, const void* beta,
+                              DeviceMemoryBase c, DeviceMemoryBase d,
+                              const BlasLt::MatmulAlgorithm& algorithm,
+                              ScratchAllocator& scratch_allocator,
+                              DeviceMemoryBase bias,
+                              blas::ProfileResult* profile_result) {
   std::unique_ptr<gpu::GpuTimer, gpu::GpuTimerDeleter> timer;
-  if (output_profile_result) {
+  if (profile_result != nullptr) {
     timer.reset(new gpu::GpuTimer(parent_));
-    if (!timer->Init() || !timer->Start(gpu::AsGpuStream(stream))) {
-      return false;
-    }
+    TF_RET_CHECK(timer->Init());
+    TF_RET_CHECK(timer->Start(gpu::AsGpuStream(stream)));
   }
 
-  bool err_on_failure = timer != nullptr;
-  bool result =
-      DoMatmulInternal(stream, err_on_failure, plan, alpha_cast, a, b,
-                       beta_cast, c, c, scratch_allocator, algorithm, bias);
-
-  if (timer && result) {
-    // GpuTimer will CHECK-fail if we Stop() it while the stream is in an error
-    // state.
-    if (!timer->Stop(gpu::AsGpuStream(stream))) {
-      return false;
-    }
-    output_profile_result->set_is_valid(true);
-    output_profile_result->set_algorithm(algorithm.index());
-    output_profile_result->set_elapsed_time_in_ms(
-        timer->GetElapsedMilliseconds());
+  void* workspace = nullptr;
+  if (algorithm.workspace_size > 0) {
+    TF_ASSIGN_OR_RETURN(
+        DeviceMemory<uint8_t> alloc,
+        scratch_allocator.AllocateBytes(algorithm.workspace_size));
+    workspace = gpu::GpuMemoryMutable(&alloc);
   }
-  return result;
+
+  {
+    absl::MutexLock lock(&mu_);
+    TF_RET_CHECK(blas_lt_ != nullptr);
+
+    // We must set the bias pointer while holding the mutex, to avoid a
+    // potential race condition from multiple threads sharing the same plan.
+    if (bias != nullptr) {
+      TF_RETURN_IF_ERROR(SetAttr(plan.op_desc.get(),
+                                 CUBLASLT_MATMUL_DESC_BIAS_POINTER,
+                                 bias.opaque()));
+    }
+
+    gpu::ScopedActivateExecutorContext sac{parent_};
+
+    SE_CUBLAS_RETURN_IF_ERROR(cublasLtMatmul(
+        blas_lt_.get(), plan.op_desc.get(), alpha, a.opaque(),
+        plan.a_desc.get(), b.opaque(), plan.b_desc.get(), beta, c.opaque(),
+        plan.c_desc.get(), d.opaque(), plan.d_desc.get(), &algorithm.algo,
+        workspace, algorithm.workspace_size, gpu::AsGpuStreamValue(stream)));
+  }
+
+  if (timer) {
+    TF_RET_CHECK(timer->Stop(gpu::AsGpuStream(stream)));
+    profile_result->set_is_valid(true);
+    profile_result->set_elapsed_time_in_ms(timer->GetElapsedMilliseconds());
+  }
+  return port::Status::OK();
 }
 
-BlasLt *GetBlasLt(Stream *stream) {
-  CUDABlas *blas = dynamic_cast<CUDABlas *>(stream->parent()->AsBlas());
+BlasLt* GetBlasLt(Stream* stream) {
+  CUDABlas* blas = dynamic_cast<CUDABlas*>(stream->parent()->AsBlas());
   return (blas != nullptr) ? &blas->blas_lt() : nullptr;
-}
-
-bool operator==(const BlasLt::MatmulPlanParams &a,
-                const BlasLt::MatmulPlanParams &b) {
-  return internal::AsTuple(a) == internal::AsTuple(b);
 }
 
 }  // namespace cuda

--- a/tensorflow/stream_executor/cuda/cuda_blas_lt.h
+++ b/tensorflow/stream_executor/cuda/cuda_blas_lt.h
@@ -18,13 +18,15 @@ limitations under the License.
 
 #include <algorithm>
 #include <memory>
+#include <optional>
 #include <string>
+#include <vector>
 
 #include "third_party/gpus/cuda/include/cublasLt.h"
 #include "third_party/gpus/cuda/include/cublas_v2.h"
 #include "third_party/gpus/cuda/include/cuda.h"
-#include "tensorflow/core/platform/thread_annotations.h"
 #include "tensorflow/stream_executor/blas.h"
+#include "tensorflow/stream_executor/cuda/cuda_blas_utils.h"
 #include "tensorflow/stream_executor/host_or_device_scalar.h"
 #include "tensorflow/stream_executor/lib/status.h"
 
@@ -36,35 +38,36 @@ class GpuExecutor;
 namespace cuda {
 
 class BlasLt {
- public:
-  struct MatmulDescDestroyer {
-    void operator()(cublasLtMatmulDesc_t matmul_desc) const {
-      cublasLtMatmulDescDestroy(matmul_desc);
-    }
-  };
-  struct LayoutDestroyer {
-    void operator()(cublasLtMatrixLayout_t layout) const {
-      cublasLtMatrixLayoutDestroy(layout);
-    }
-  };
-  struct MatmulPreferenceDestroyer {
-    void operator()(cublasLtMatmulPreference_t matmul_pref) const {
-      cublasLtMatmulPreferenceDestroy(matmul_pref);
-    }
-  };
-  using UniqueOpDesc =
-      std::unique_ptr<std::remove_pointer<cublasLtMatmulDesc_t>::type,
-                      MatmulDescDestroyer>;
-  using UniqueLayoutDesc =
-      std::unique_ptr<std::remove_pointer<cublasLtMatrixLayout_t>::type,
-                      LayoutDestroyer>;
-  using UniqueMatmulPreference =
-      std::unique_ptr<std::remove_pointer<cublasLtMatmulPreference_t>::type,
-                      MatmulPreferenceDestroyer>;
-
   template <typename T>
   using Owned =
       std::unique_ptr<std::remove_pointer_t<T>, cublasStatus_t (*)(T)>;
+
+ public:
+  class MatrixLayout {
+   public:
+    enum class Order { kRowMajor, kColumnMajor };
+
+    // If `leading_dim_stride` is not specified, it defaults to:
+    //  - `num_cols` if `order == kRowMajor`,
+    //  - `num_rows` if `order == kColumnMajor`.
+    // If `batch_stride` is not specified, it defaults to `num_rows * num_cols`
+    // if `batch_size > 1`, otherwise `0`.
+    static port::StatusOr<MatrixLayout> Create(
+        blas::DataType type, size_t num_rows, size_t num_cols, Order order,
+        size_t batch_size = 1,
+        std::optional<int64_t> leading_dim_stride = std::nullopt,
+        std::optional<int64_t> batch_stride = std::nullopt);
+
+    cudaDataType_t type() const;
+
+    cublasLtMatrixLayout_t get() const { return handle_.get(); }
+
+   private:
+    explicit MatrixLayout(cublasLtMatrixLayout_t handle)
+        : handle_(handle, cublasLtMatrixLayoutDestroy) {}
+
+    Owned<cublasLtMatrixLayout_t> handle_;
+  };
 
   enum class Epilogue {
     kDefault = 1,                   // No special postprocessing
@@ -79,212 +82,131 @@ class BlasLt {
     kDevice,
   };
 
-  // Parameters for the CreateBlasLtMatmulPlan method.
-  struct MatmulPlanParams {
-    std::string ToString() const;
-
-    blas::DataType ab_type;
-    blas::DataType c_type;
-    blas::ComputationType computation_type;
-    PointerMode pointer_mode;
-    Epilogue epilogue;
-    blas::Transpose transa;
-    blas::Transpose transb;
-    uint64_t m;
-    uint64_t n;
-    uint64_t k;
-    int64_t lda;
-    int64_t ldb;
-    int64_t ldc;
-    int batch_count = 1;
-    int64_t stride_a = 0;
-    int64_t stride_b = 0;
-    int64_t stride_c = 0;
-  };
-
-  class MatmulAlgorithm {
+  class MatmulDesc {
    public:
-    MatmulAlgorithm(blas::AlgorithmType index, cublasLtMatmulAlgo_t algo,
-                    size_t workspace_size)
-        : index_(index), algo_(algo), workspace_size_(workspace_size) {}
+    static port::StatusOr<MatmulDesc> Create(
+        blas::ComputationType compute_type, blas::DataType scale_type,
+        blas::Transpose trans_a = blas::Transpose::kNoTranspose,
+        blas::Transpose trans_b = blas::Transpose::kNoTranspose,
+        Epilogue epilogue = Epilogue::kDefault,
+        PointerMode pointer_mode = PointerMode::kHost);
 
-    blas::AlgorithmType index() const { return index_; }
+    cublasComputeType_t compute_type() const;
+    cudaDataType_t scale_type() const;
+    cublasLtPointerMode_t pointer_mode() const;
 
-    size_t workspace_size() const { return workspace_size_; }
-
-    const cublasLtMatmulAlgo_t *algo() const { return &algo_; }
-
-    int algo_id() const;
+    cublasLtMatmulDesc_t get() const { return handle_.get(); }
 
    private:
-    blas::AlgorithmType index_;
-    cublasLtMatmulAlgo_t algo_;
-    size_t workspace_size_;
+    explicit MatmulDesc(cublasLtMatmulDesc_t handle)
+        : handle_(handle, cublasLtMatmulDescDestroy) {}
+
+    Owned<cublasLtMatmulDesc_t> handle_;
   };
 
-  class MatmulPlan {
+  // TODO(cjfj): Add consistency checks for types, shapes, etc.?
+  struct MatmulPlan {
+    MatmulDesc op_desc;
+    MatrixLayout a_desc;
+    MatrixLayout b_desc;
+    MatrixLayout c_desc;
+    MatrixLayout d_desc;
+  };
+
+  class MatmulPreference {
    public:
-    port::Status init(const MatmulPlanParams &p);
+    static port::StatusOr<MatmulPreference> Create(size_t max_workspace_size);
 
-    cublasLtMatmulDesc_t op_desc() const { return op_desc_.get(); }
-    cublasLtMatrixLayout_t a_desc() const { return a_desc_.get(); }
-    cublasLtMatrixLayout_t b_desc() const { return b_desc_.get(); }
-    cublasLtMatrixLayout_t c_desc() const { return c_desc_.get(); }
-    cublasLtMatrixLayout_t d_desc() const { return d_desc_.get(); }
-    cublasLtMatrixLayout_t a_remainder_desc() const {
-      return a_remainder_desc_.get();
-    }
-    cublasLtMatrixLayout_t b_remainder_desc() const {
-      return b_remainder_desc_.get();
-    }
-    cublasLtMatrixLayout_t c_remainder_desc() const {
-      return c_remainder_desc_.get();
-    }
-    cublasLtMatrixLayout_t d_remainder_desc() const {
-      return d_remainder_desc_.get();
-    }
-
-    const MatmulPlanParams &params() const { return params_; }
-    blas::DataType scale_type() const { return scale_type_; }
-    blas::DataType ab_type() const { return params_.ab_type; }
-    blas::DataType c_type() const { return params_.c_type; }
-    int capped_batch_count() const {
-      return std::min(params_.batch_count, kMaxBatchCount);
-    }
-    int remainder_batch_count() const { return remainder_batch_count_; }
-
-    // Note: Must be const to satisfy API. This is always called before the plan
-    // is executed, so the state change is not observed in subsequent
-    // executions.
-    bool SetBiasPointer(const void *bias) const;
+    cublasLtMatmulPreference_t get() const { return handle_.get(); }
 
    private:
-    // In some cases cublasLt does not support large batch sizes, so we need to
-    // split up such cases into multiple calls.
-    static constexpr int kMaxBatchCount = 65535;
-    MatmulPlanParams params_;
-    blas::DataType scale_type_;
-    UniqueOpDesc op_desc_;
-    // These have batch count set to capped_batch_count().
-    UniqueLayoutDesc a_desc_;
-    UniqueLayoutDesc b_desc_;
-    UniqueLayoutDesc c_desc_;
-    UniqueLayoutDesc d_desc_;
-    int remainder_batch_count_;
-    // These have batch count set to remainder_batch_count_, and are only
-    // created if params_.batch_count > kMaxBatchSize.
-    UniqueLayoutDesc a_remainder_desc_;
-    UniqueLayoutDesc b_remainder_desc_;
-    UniqueLayoutDesc c_remainder_desc_;
-    UniqueLayoutDesc d_remainder_desc_;
+    explicit MatmulPreference(cublasLtMatmulPreference_t handle)
+        : handle_(handle, cublasLtMatmulPreferenceDestroy) {}
+
+    Owned<cublasLtMatmulPreference_t> handle_;
   };
 
-  // Creates a plan which can be passed to DoMatmul(). When possible, plans
-  // should be created once and reused for multiple calls to DoMatmul().
-  static port::StatusOr<MatmulPlan> CreateMatmulPlan(
-      const MatmulPlanParams &params);
+  struct MatmulAlgorithm {
+    cublasLtMatmulAlgo_t algo;
+    size_t workspace_size;
+  };
 
-  explicit BlasLt(gpu::GpuExecutor *parent)
+  explicit BlasLt(gpu::GpuExecutor* parent)
       : parent_(parent), blas_lt_(nullptr, cublasLtDestroy) {}
 
   port::Status Init();
 
   // Gets a list of supported algorithms for DoMatmul. The algorithms are
   // returned in the order of increasing estimated compute time according to an
-  // internal heuristic. The first returned algorithm can be used as the default
-  // algorithm if no autotuning is to be performed.
+  // internal heuristic.
   port::StatusOr<std::vector<MatmulAlgorithm>> GetMatmulAlgorithms(
-      const MatmulPlan &plan, size_t max_workspace_size,
-      int max_algorithm_count);
+      const MatmulPlan& plan, const MatmulPreference& preference,
+      size_t max_algorithm_count = 128);
 
-  // Executes a blaslt matmul operation on the stream. If output_profile_result
-  // is not nullptr, the operation is profiled, error messages are
-  // suppressed, and output_profile_result->algorithm() is set to
-  // algorithm->index(). If epilogue was set to kBias or kBiasThenReLU when
-  // creating the plan, the bias argument here must refer to a valid device
-  // vector of length equal to the number of rows in matrix c. If epilogue was
-  // set to any other value then the bias argument here must be null. The bias
-  // vector is broadcast across the batch dimension.
-  // Note that the data types of a and b (c and bias) must match the ab_type
-  // (c_type) with which the plan was created, and the data types of alpha and
-  // beta must match the data type of c.
-  bool DoMatmul(Stream *stream, const MatmulPlan &plan,
-                const HostOrDeviceScalar<void> &alpha, DeviceMemoryBase a,
-                DeviceMemoryBase b, const HostOrDeviceScalar<void> &beta,
-                DeviceMemoryBase c, ScratchAllocator *scratch_allocator,
-                const MatmulAlgorithm &algorithm, DeviceMemoryBase bias,
-                blas::ProfileResult *output_profile_result);
+  template <typename AB, typename CD, typename Scale>
+  port::Status DoMatmul(Stream* stream, const MatmulPlan& plan,
+                        const HostOrDeviceScalar<Scale>& alpha,
+                        const DeviceMemory<AB>& a, const DeviceMemory<AB>& b,
+                        const HostOrDeviceScalar<Scale>& beta,
+                        const DeviceMemory<CD>& c, DeviceMemory<CD>& d,
+                        const MatmulAlgorithm& algorithm,
+                        ScratchAllocator& scratch_allocator,
+                        const DeviceMemory<CD>& bias = {},
+                        blas::ProfileResult* profile_result = nullptr) {
+    if (AsCudaDataType(blas::ToDataType<Scale>::value) !=
+        plan.op_desc.scale_type()) {
+      return port::InvalidArgumentError("mismatched scale types");
+    }
 
-  template <typename ABType, typename CType>
-  bool DoMatmul(Stream *stream, const MatmulPlan &plan,
-                const HostOrDeviceScalar<CType> &alpha,
-                const DeviceMemory<ABType> &a, const DeviceMemory<ABType> &b,
-                const HostOrDeviceScalar<CType> &beta, DeviceMemory<CType> *c,
-                ScratchAllocator *scratch_allocator,
-                const MatmulAlgorithm &algorithm,
-                const DeviceMemory<CType> &bias = {},
-                blas::ProfileResult *output_profile_result = nullptr) {
-    constexpr blas::DataType ab_type = blas::ToDataType<ABType>::value;
-    if (ab_type != plan.ab_type()) {
-      VLOG(2) << "DoMatmul returning false because a and b type does "
-                 "not match plan: expected "
-              << plan.ab_type() << ", got " << ab_type;
-      return false;
+    bool expect_scale_factor_on_device =
+        (plan.op_desc.pointer_mode() == CUBLASLT_POINTER_MODE_DEVICE);
+
+    if (alpha.on_device() != expect_scale_factor_on_device) {
+      return port::InvalidArgumentError("wrong location for alpha");
     }
-    constexpr blas::DataType c_type = blas::ToDataType<CType>::value;
-    if (c_type != plan.c_type()) {
-      VLOG(2) << "DoMatmul returning false because c type does "
-                 "not match plan: expected "
-              << plan.c_type() << ", got " << c_type;
-      return false;
+
+    if (beta.on_device() != expect_scale_factor_on_device) {
+      return port::InvalidArgumentError("wrong location for beta");
     }
-    return DoMatmul(stream, plan, alpha, a, b, beta, *c, scratch_allocator,
-                    algorithm, bias, output_profile_result);
+
+    if (AsCudaDataType(blas::ToDataType<AB>::value) != plan.a_desc.type()) {
+      return port::InvalidArgumentError("mismatched A matrix types");
+    }
+
+    if (AsCudaDataType(blas::ToDataType<AB>::value) != plan.b_desc.type()) {
+      return port::InvalidArgumentError("mismatched B matrix types");
+    }
+
+    if (AsCudaDataType(blas::ToDataType<CD>::value) != plan.c_desc.type()) {
+      return port::InvalidArgumentError("mismatched C matrix types");
+    }
+
+    if (AsCudaDataType(blas::ToDataType<CD>::value) != plan.d_desc.type()) {
+      return port::InvalidArgumentError("mismatched D matrix types");
+    }
+
+    return DoMatmul(stream, plan, alpha.opaque(), a, b, beta.opaque(), c, d,
+                    algorithm, scratch_allocator, bias, profile_result);
   }
 
  private:
-  bool DoMatmulInternal(Stream *stream, bool err_on_failure,
-                        const MatmulPlan &plan,
-                        const HostOrDeviceScalar<void> &alpha,
-                        DeviceMemoryBase a, DeviceMemoryBase b,
-                        const HostOrDeviceScalar<void> &beta,
+  port::Status DoMatmul(Stream* stream, const MatmulPlan& plan,
+                        const void* alpha, DeviceMemoryBase a,
+                        DeviceMemoryBase b, const void* beta,
                         DeviceMemoryBase c, DeviceMemoryBase d,
-                        ScratchAllocator *scratch_allocator,
-                        const MatmulAlgorithm &algorithm,
-                        DeviceMemoryBase bias);
+                        const MatmulAlgorithm& algorithm,
+                        ScratchAllocator& scratch_allocator,
+                        DeviceMemoryBase bias,
+                        blas::ProfileResult* profile_result);
 
-  // Helper function for implementing GetBlasLtMatmulAlgorithms.
-  port::StatusOr<std::vector<MatmulAlgorithm>> GetMatmulAlgorithmsInternal(
-      const MatmulPlan &plan, size_t max_workspace_size,
-      int max_algorithm_count, bool for_remainder_batch = false);
-
-  gpu::GpuExecutor *parent_;
+  gpu::GpuExecutor* parent_;
 
   absl::Mutex mu_;
-  Owned<cublasLtHandle_t> blas_lt_ TF_GUARDED_BY(mu_);
+  Owned<cublasLtHandle_t> blas_lt_ ABSL_GUARDED_BY(mu_);
 };
 
 // Returns `BlasLt` implementation for a stream if available, or `nullptr`.
-BlasLt *GetBlasLt(Stream *stream);
-
-namespace internal {
-
-inline auto AsTuple(const BlasLt::MatmulPlanParams &p) {
-  return std::make_tuple(p.ab_type, p.c_type, p.computation_type,
-                         p.pointer_mode, p.epilogue, p.transa, p.transb, p.m,
-                         p.n, p.k, p.lda, p.ldb, p.ldc, p.batch_count,
-                         p.stride_a, p.stride_b, p.stride_c);
-}
-
-}  // namespace internal
-
-bool operator==(const BlasLt::MatmulPlanParams &a,
-                const BlasLt::MatmulPlanParams &b);
-
-template <typename H>
-H AbslHashValue(H h, const BlasLt::MatmulPlanParams &plan_params) {
-  return H::combine(std::move(h), internal::AsTuple(plan_params));
-}
+BlasLt* GetBlasLt(Stream* stream);
 
 }  // namespace cuda
 }  // namespace stream_executor

--- a/tensorflow/stream_executor/host_or_device_scalar.h
+++ b/tensorflow/stream_executor/host_or_device_scalar.h
@@ -16,192 +16,37 @@ limitations under the License.
 #ifndef TENSORFLOW_STREAM_EXECUTOR_HOST_OR_DEVICE_SCALAR_H_
 #define TENSORFLOW_STREAM_EXECUTOR_HOST_OR_DEVICE_SCALAR_H_
 
-#include "tensorflow/stream_executor/data_type.h"
+#include <utility>
+#include <variant>
+
 #include "tensorflow/stream_executor/device_memory.h"
-#include "tensorflow/stream_executor/platform/logging.h"
 
 namespace stream_executor {
 
 // Allows to represent a value that is either a host scalar or a scalar stored
-// on the GPU device.
-// See also the specialization for ElemT=void below.
-template <typename ElemT>
+// on the device.
+template <typename T>
 class HostOrDeviceScalar {
  public:
-  // Not marked as explicit because when using this constructor, we usually want
-  // to set this to a compile-time constant.
-  HostOrDeviceScalar(ElemT value) : value_(value), is_pointer_(false) {}
-  explicit HostOrDeviceScalar(const DeviceMemory<ElemT>& pointer)
-      : pointer_(pointer), is_pointer_(true) {
-    CHECK_EQ(1, pointer.ElementCount());
+  explicit HostOrDeviceScalar(T host_value) : value_(std::move(host_value)) {}
+  explicit HostOrDeviceScalar(DeviceMemory<T> device_ptr)
+      : value_(std::move(device_ptr)) {
+    CHECK_EQ(1, device_ptr.ElementCount());
   }
 
-  bool is_pointer() const { return is_pointer_; }
-  const DeviceMemory<ElemT>& pointer() const {
-    CHECK(is_pointer());
-    return pointer_;
+  bool on_device() const {
+    return std::holds_alternative<DeviceMemory<T>>(value_);
   }
-  const ElemT& value() const {
-    CHECK(!is_pointer());
-    return value_;
+
+  const void* opaque() const {
+    return on_device() ? std::get<DeviceMemory<T>>(value_).opaque()
+                       : &std::get<T>(value_);
   }
 
  private:
-  union {
-    ElemT value_;
-    DeviceMemory<ElemT> pointer_;
-  };
-  bool is_pointer_;
+  std::variant<T, DeviceMemory<T>> value_;
 };
-
-// Specialization for wrapping a dynamically-typed value (via type erasure).
-template <>
-class HostOrDeviceScalar<void> {
- public:
-  using DataType = dnn::DataType;
-
-  // Constructors not marked as explicit because when using this constructor, we
-  // usually want to set this to a compile-time constant.
-
-  // NOLINTNEXTLINE google-explicit-constructor
-  HostOrDeviceScalar(float value)
-      : float_(value), is_pointer_(false), dtype_(DataType::kFloat) {}
-  // NOLINTNEXTLINE google-explicit-constructor
-  HostOrDeviceScalar(double value)
-      : double_(value), is_pointer_(false), dtype_(DataType::kDouble) {}
-  // NOLINTNEXTLINE google-explicit-constructor
-  HostOrDeviceScalar(Eigen::half value)
-      : half_(value), is_pointer_(false), dtype_(DataType::kHalf) {}
-  // NOLINTNEXTLINE google-explicit-constructor
-  HostOrDeviceScalar(int8 value)
-      : int8_(value), is_pointer_(false), dtype_(DataType::kInt8) {}
-  // NOLINTNEXTLINE google-explicit-constructor
-  HostOrDeviceScalar(int32 value)
-      : int32_(value), is_pointer_(false), dtype_(DataType::kInt32) {}
-  // NOLINTNEXTLINE google-explicit-constructor
-  HostOrDeviceScalar(std::complex<float> value)
-      : complex_float_(value),
-        is_pointer_(false),
-        dtype_(DataType::kComplexFloat) {}
-  // NOLINTNEXTLINE google-explicit-constructor
-  HostOrDeviceScalar(std::complex<double> value)
-      : complex_double_(value),
-        is_pointer_(false),
-        dtype_(DataType::kComplexDouble) {}
-  template <typename T>
-  explicit HostOrDeviceScalar(const DeviceMemory<T>& pointer)
-      : pointer_(pointer),
-        is_pointer_(true),
-        dtype_(dnn::ToDataType<T>::value) {
-    CHECK_EQ(1, pointer.ElementCount());
-  }
-  // Construct from statically-typed version.
-  template <typename T, typename std::enable_if<!std::is_same<T, void>::value,
-                                                int>::type = 0>
-  // NOLINTNEXTLINE google-explicit-constructor
-  HostOrDeviceScalar(const HostOrDeviceScalar<T>& other) {
-    if (other.is_pointer()) {
-      *this = HostOrDeviceScalar(other.pointer());
-    } else {
-      *this = HostOrDeviceScalar(other.value());
-    }
-  }
-
-  bool is_pointer() const { return is_pointer_; }
-  template <typename T>
-  const DeviceMemory<T>& pointer() const {
-    CHECK(is_pointer());
-    CHECK(dtype_ == dnn::ToDataType<T>::value);
-    return pointer_;
-  }
-  template <typename T>
-  const T& value() const {
-    CHECK(!is_pointer());
-    CHECK(dtype_ == dnn::ToDataType<T>::value);
-    return value_impl<T>();
-  }
-  const DeviceMemoryBase& opaque_pointer() const {
-    CHECK(is_pointer());
-    return pointer_;
-  }
-  const void* opaque_value() const {
-    CHECK(!is_pointer());
-    switch (dtype_) {
-      case DataType::kFloat:
-        return &float_;
-      case DataType::kDouble:
-        return &double_;
-      case DataType::kHalf:
-        return &half_;
-      case DataType::kInt8:
-        return &int8_;
-      case DataType::kInt32:
-        return &int32_;
-      case DataType::kComplexFloat:
-        return &complex_float_;
-      case DataType::kComplexDouble:
-        return &complex_double_;
-      default:
-        return nullptr;
-    }
-  }
-  DataType data_type() const { return dtype_; }
-
- private:
-  template <typename T>
-  const T& value_impl() const;
-
-  union {
-    float float_;
-    double double_;
-    Eigen::half half_;
-    int8 int8_;
-    int32 int32_;
-    std::complex<float> complex_float_;
-    std::complex<double> complex_double_;
-    DeviceMemoryBase pointer_;
-  };
-  bool is_pointer_;
-  DataType dtype_;
-};
-
-template <>
-inline const float& HostOrDeviceScalar<void>::value_impl<float>() const {
-  return float_;
-}
-
-template <>
-inline const double& HostOrDeviceScalar<void>::value_impl<double>() const {
-  return double_;
-}
-
-template <>
-inline const Eigen::half& HostOrDeviceScalar<void>::value_impl<Eigen::half>()
-    const {
-  return half_;
-}
-
-template <>
-inline const int8& HostOrDeviceScalar<void>::value_impl<int8>() const {
-  return int8_;
-}
-
-template <>
-inline const int32& HostOrDeviceScalar<void>::value_impl<int32>() const {
-  return int32_;
-}
-
-template <>
-inline const std::complex<float>&
-HostOrDeviceScalar<void>::value_impl<std::complex<float>>() const {
-  return complex_float_;
-}
-
-template <>
-inline const std::complex<double>&
-HostOrDeviceScalar<void>::value_impl<std::complex<double>>() const {
-  return complex_double_;
-}
 
 }  // namespace stream_executor
+
 #endif  // TENSORFLOW_STREAM_EXECUTOR_HOST_OR_DEVICE_SCALAR_H_

--- a/tensorflow/stream_executor/lib/BUILD
+++ b/tensorflow/stream_executor/lib/BUILD
@@ -35,6 +35,7 @@ cc_library(
     hdrs = glob(["**/*.h"]),
     linkopts = if_windows(["-DEFAULTLIB:ws2_32.lib"]),
     deps = [
+        "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/types:span",


### PR DESCRIPTION
[SE/XLA:GPU/TF] Start cleaning up BlasLt API.

- SE:
  - Remove most of `HostOrDeviceScalar`.
  - Remove complicated handling of edge-case for very large batch sizes.
  - Remove alignment hack which no longer appears necessary.
- TF:
  - Move plan params into TF and simplify it.
- XLA:GPU:
  - De-duplicate more code in gemm auto-tuner.
  - Cache plan and algorithm on the gemm thunk.
  - Record the algorithm idx in the gemm config, eliminating the need for the cache.
